### PR TITLE
fix: remove networkidle to resolve hanging CI tests

### DIFF
--- a/e2e/5g-cross-validation.spec.ts
+++ b/e2e/5g-cross-validation.spec.ts
@@ -264,7 +264,7 @@ test.describe('SUCI Flow: Java vs OpenSSL Validation', () => {
 
   test.skip('Validate OpenSSL implementation in app', async ({ page }) => {
     await page.goto('/learn/5g-security')
-    await page.waitForLoadState('networkidle')
+    await expect(page.getByRole('heading', { name: '5G Security' })).toBeVisible({ timeout: 30000 })
 
     // Enable test mode with deterministic vectors
     await page.evaluate(() => {

--- a/e2e/5g-validation.spec.ts
+++ b/e2e/5g-validation.spec.ts
@@ -142,7 +142,7 @@ test.describe('5G SUCI Validation', () => {
   test('validate Profile B (P-256) Full Flow', async ({ page }) => {
     // 1. Navigate
     await page.goto('/learn/5g-security')
-    await page.waitForLoadState('networkidle')
+    await expect(page.getByRole('heading', { name: '5G Security' })).toBeVisible({ timeout: 30000 })
 
     // 2. Inject Test Vectors
     await page.evaluate((vectors) => {
@@ -178,7 +178,8 @@ test.describe('5G SUCI Validation', () => {
     await page.goto('/learn/5g-security')
 
     // Wait for app to be interactive
-    await page.waitForLoadState('networkidle')
+    // Wait for app to be interactive
+    await expect(page.getByRole('heading', { name: '5G Security' })).toBeVisible({ timeout: 30000 })
 
     // Inject
     await page.evaluate((vectors) => {
@@ -221,7 +222,7 @@ test.describe('5G SUCI Validation', () => {
 
   test('validate Subscriber Authentication (MILENAGE)', async ({ page }) => {
     await page.goto('/learn/5g-security')
-    await page.waitForLoadState('networkidle')
+    await expect(page.getByRole('heading', { name: '5G Security' })).toBeVisible({ timeout: 30000 })
 
     // Inject
     await page.evaluate((vectors) => {

--- a/e2e/debug-dom.spec.ts
+++ b/e2e/debug-dom.spec.ts
@@ -1,8 +1,8 @@
-import { test } from '@playwright/test'
+import { test, expect } from '@playwright/test'
 
 test('debug page content', async ({ page }) => {
   await page.goto('/learn/5g-security')
-  await page.waitForLoadState('networkidle')
+  await expect(page.getByRole('heading', { name: '5G Security' })).toBeVisible()
   await page.waitForTimeout(3000) // Wait plenty
   const content = await page.content()
   console.log('--- PAGE CONTENT START ---')

--- a/e2e/digital-id.spec.ts
+++ b/e2e/digital-id.spec.ts
@@ -20,8 +20,7 @@ test.describe('EUDI Digital Identity Wallet Module', () => {
     await page.goto('/')
     await page.getByRole('button', { name: 'Learn' }).click()
 
-    // Wait for modules to load
-    await page.waitForLoadState('networkidle')
+    // Wait for modules to load - avoiding networkidle as it causes hangs in CI
     const digitalIdCard = page.getByRole('heading', { name: 'Digital ID', exact: true })
     await expect(digitalIdCard).toBeVisible({ timeout: 30000 })
     await digitalIdCard.click()
@@ -35,15 +34,20 @@ test.describe('EUDI Digital Identity Wallet Module', () => {
     // -------------------------------------------------------------
     await test.step('PID Issuance Flow', async () => {
       // Select PID Issuer
-      await page.getByRole('button', { name: 'PID Issuer' }).click()
+      const pidIssuerBtn = page.getByRole('button', { name: 'PID Issuer' })
+      await expect(pidIssuerBtn).toBeVisible()
+      await pidIssuerBtn.click()
+
       await expect(page.getByText('Motor Vehicle Authority')).toBeVisible()
 
       // Step 1: Start Flow
-      await page.getByRole('button', { name: 'Start Issuance Flow' }).click()
+      const startBtn = page.getByRole('button', { name: 'Start Issuance Flow' })
+      await expect(startBtn).toBeVisible()
+      await startBtn.click()
 
       // Step 2: Authenticate
       const authBtn = page.getByRole('button', { name: 'Proceed with Authentication' })
-      await expect(authBtn).toBeVisible({ timeout: 5000 })
+      await expect(authBtn).toBeVisible({ timeout: 10000 })
       await authBtn.click()
 
       // Step 3: Wait for Completion (includes delays for logs)

--- a/e2e/ethereum-flow.spec.ts
+++ b/e2e/ethereum-flow.spec.ts
@@ -22,7 +22,7 @@ test('Ethereum Flow E2E', async ({ page }) => {
   // 1. Navigate to Digital Assets Module
   await test.step('Navigate to Digital Assets', async () => {
     await page.goto('/learn')
-    await page.waitForLoadState('networkidle')
+    // await page.waitForLoadState('networkidle') - Causes hacks
     await page.getByText('Digital Assets', { exact: true }).click()
     await expect(page.getByText('Module 1: Bitcoin')).toBeVisible({ timeout: 15000 })
   })

--- a/e2e/inspect-dom.spec.ts
+++ b/e2e/inspect-dom.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test'
 
 test('inspect DOM structure', async ({ page }) => {
   await page.goto('/learn/5g-security')
-  await page.waitForLoadState('networkidle')
+  await expect(page.getByRole('heading', { name: '5G Security' })).toBeVisible()
 
   // Enable test mode
   await page.evaluate(() => {

--- a/e2e/inspect-output.spec.ts
+++ b/e2e/inspect-output.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test'
 
 test('inspect output after execution', async ({ page }) => {
   await page.goto('/learn/5g-security')
-  await page.waitForLoadState('networkidle')
+  await expect(page.getByRole('heading', { name: '5G Security' })).toBeVisible()
 
   await page.evaluate(() => {
     // @ts-ignore

--- a/e2e/pki-workshop.spec.ts
+++ b/e2e/pki-workshop.spec.ts
@@ -8,7 +8,6 @@ test.describe('PKI Workshop Module', () => {
     await page.getByRole('button', { name: 'Learn' }).click()
 
     // Select PKI Workshop from Dashboard
-    await page.waitForLoadState('networkidle')
     const card = page.getByRole('heading', { name: 'PKI', exact: true })
     await expect(card).toBeVisible({ timeout: 30000 })
     await card.click()

--- a/e2e/production.spec.ts
+++ b/e2e/production.spec.ts
@@ -19,7 +19,8 @@ test.describe('Production Smoke Tests', () => {
 
     await page.goto(PROD_URL)
     // Wait for the app to be ready (hydration)
-    await page.waitForLoadState('networkidle')
+    // await page.waitForLoadState('networkidle') - Causes hang
+    await expect(page).toHaveTitle(/PQC Today/, { timeout: 30000 })
   })
 
   test('Asset Integrity Check', async ({ page }) => {

--- a/e2e/verify_hd_wallet.spec.ts
+++ b/e2e/verify_hd_wallet.spec.ts
@@ -17,7 +17,7 @@ test('verify hd wallet flow', async ({ page }) => {
 
   // 1. Navigate to Digital Assets directly
   await page.goto('/learn/digital-assets')
-  await page.waitForLoadState('networkidle')
+  await expect(page.getByRole('button', { name: '4 HD Wallet' })).toBeVisible({ timeout: 30000 })
 
   // 2. Select HD Wallet Module (Step 4)
   await page.getByRole('button', { name: '4 HD Wallet' }).click()


### PR DESCRIPTION
Removes networkidle from E2E tests to prevent apparent hangs during polling/WASM loading. Verified locally.