### PR TITLE
feat(ux): renderer-pass closeout (P15-P1-07 + P18-P1-01 + P18-P1-02)

### DIFF
--- a/src/components/About/AboutNextStepCTA.test.tsx
+++ b/src/components/About/AboutNextStepCTA.test.tsx
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-3.0-only
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { AboutNextStepCTA } from './AboutNextStepCTA'
+import { usePersonaStore } from '@/store/usePersonaStore'
+import '@testing-library/jest-dom'
+
+vi.mock('@/utils/analytics', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/analytics')>()
+  return {
+    ...actual,
+    logAboutNextStepCta: vi.fn(),
+  }
+})
+
+const renderWithRoute = () =>
+  render(
+    <MemoryRouter>
+      <AboutNextStepCTA />
+    </MemoryRouter>
+  )
+
+describe('AboutNextStepCTA', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    usePersonaStore.setState({ selectedPersona: null })
+    vi.clearAllMocks()
+  })
+
+  it('renders the generic fallback when no persona is selected', () => {
+    renderWithRoute()
+    expect(screen.getByText(/Pick a starting point/)).toBeInTheDocument()
+    expect(screen.getByText(/about your role/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Find my starting point/ })).toHaveAttribute(
+      'href',
+      '/?picker=open'
+    )
+  })
+
+  it('renders the executive CTA when persona is executive', () => {
+    usePersonaStore.setState({ selectedPersona: 'executive' })
+    renderWithRoute()
+    expect(screen.getByText(/Take the 3-minute assessment/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Start the assessment/ })).toHaveAttribute(
+      'href',
+      '/assess?mode=quick'
+    )
+  })
+
+  it('renders the curious CTA when persona is curious', () => {
+    usePersonaStore.setState({ selectedPersona: 'curious' })
+    renderWithRoute()
+    expect(screen.getByText(/Start with the 5-minute intro/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Open the intro/ })).toHaveAttribute(
+      'href',
+      '/learn/pqc-101'
+    )
+  })
+
+  it('renders the architect CTA when persona is architect', () => {
+    usePersonaStore.setState({ selectedPersona: 'architect' })
+    renderWithRoute()
+    expect(screen.getByText(/Map the standards landscape/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Explore the landscape/ })).toHaveAttribute(
+      'href',
+      '/compliance?tab=landscape'
+    )
+  })
+
+  it('fires logAboutNextStepCta when the CTA is clicked', async () => {
+    usePersonaStore.setState({ selectedPersona: 'developer' })
+    const { logAboutNextStepCta } = await import('@/utils/analytics')
+    renderWithRoute()
+    fireEvent.click(screen.getByRole('link', { name: /Open the library/ }))
+    expect(vi.mocked(logAboutNextStepCta)).toHaveBeenCalledWith('library-protocols')
+  })
+
+  it('renders a CTA for every persona id', () => {
+    const personas: Array<'executive' | 'developer' | 'architect' | 'ops' | 'researcher' | 'curious'> = [
+      'executive',
+      'developer',
+      'architect',
+      'ops',
+      'researcher',
+      'curious',
+    ]
+    for (const p of personas) {
+      usePersonaStore.setState({ selectedPersona: p })
+      const { unmount } = renderWithRoute()
+      // Every persona renders a button-style link with an accessible name
+      expect(screen.getAllByRole('link').length).toBeGreaterThan(0)
+      unmount()
+    }
+  })
+})

--- a/src/components/About/AboutNextStepCTA.test.tsx
+++ b/src/components/About/AboutNextStepCTA.test.tsx
@@ -77,14 +77,9 @@ describe('AboutNextStepCTA', () => {
   })
 
   it('renders a CTA for every persona id', () => {
-    const personas: Array<'executive' | 'developer' | 'architect' | 'ops' | 'researcher' | 'curious'> = [
-      'executive',
-      'developer',
-      'architect',
-      'ops',
-      'researcher',
-      'curious',
-    ]
+    const personas: Array<
+      'executive' | 'developer' | 'architect' | 'ops' | 'researcher' | 'curious'
+    > = ['executive', 'developer', 'architect', 'ops', 'researcher', 'curious']
     for (const p of personas) {
       usePersonaStore.setState({ selectedPersona: p })
       const { unmount } = renderWithRoute()

--- a/src/components/About/AboutNextStepCTA.tsx
+++ b/src/components/About/AboutNextStepCTA.tsx
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-3.0-only
+import { Link } from 'react-router-dom'
+import { ArrowRight, Briefcase, Code2, Wrench, FlaskConical, Layers, Compass } from 'lucide-react'
+import { buttonVariants } from '@/components/ui/button-variants'
+import { cn } from '@/lib/utils'
+import { usePersonaStore } from '@/store/usePersonaStore'
+import { logAboutNextStepCta } from '@/utils/analytics'
+import type { PersonaId } from '@/data/learningPersonas'
+
+interface CtaSpec {
+  icon: React.ReactNode
+  title: string
+  body: string
+  to: string
+  destination: string
+  cta: string
+}
+
+const PERSONA_CTAS: Record<PersonaId, CtaSpec> = {
+  executive: {
+    icon: <Briefcase size={20} className="text-primary" />,
+    title: 'Take the 3-minute assessment',
+    body: 'Get a board-ready brief on your organization’s PQC posture, with the regulatory deadlines that matter most to your jurisdiction.',
+    to: '/assess?mode=quick',
+    destination: 'assess-quick',
+    cta: 'Start the assessment',
+  },
+  developer: {
+    icon: <Code2 size={20} className="text-primary" />,
+    title: 'Browse PQC-ready libraries',
+    body: 'See which crypto libraries already ship FIPS 203/204/205 implementations and what JOSE/COSE wire formats are stable today.',
+    to: '/library?cat=Protocols',
+    destination: 'library-protocols',
+    cta: 'Open the library',
+  },
+  architect: {
+    icon: <Layers size={20} className="text-primary" />,
+    title: 'Map the standards landscape',
+    body: 'Walk the active PQC standards — NIST, BSI, ANSSI, ETSI — and their implementation timelines so you can sequence your migration plan.',
+    to: '/compliance?tab=landscape',
+    destination: 'compliance-landscape',
+    cta: 'Explore the landscape',
+  },
+  ops: {
+    icon: <Wrench size={20} className="text-primary" />,
+    title: 'Watch the regulatory clock',
+    body: 'Pull up the certification-rotation timeline so you know which frameworks enter active enforcement next quarter.',
+    to: '/compliance?tab=foryou',
+    destination: 'compliance-rotation',
+    cta: 'See the clock',
+  },
+  researcher: {
+    icon: <FlaskConical size={20} className="text-primary" />,
+    title: 'Read the source standards',
+    body: 'Jump straight to FIPS 203/204/205, RFC 9964, and the active IETF drafts — all cited with passage-level provenance.',
+    to: '/library?cat=Standards',
+    destination: 'library-standards',
+    cta: 'Open the standards shelf',
+  },
+  curious: {
+    icon: <Compass size={20} className="text-primary" />,
+    title: 'Start with the 5-minute intro',
+    body: 'The “Why PQC?” module explains the quantum threat in plain English — no math, no acronyms, just the picture.',
+    to: '/learn/pqc-101',
+    destination: 'module-pqc-101',
+    cta: 'Open the intro',
+  },
+}
+
+const DEFAULT_CTA: CtaSpec = {
+  icon: <Compass size={20} className="text-primary" />,
+  title: 'Pick a starting point',
+  body: 'Tell us a bit about your role and we will route you to the page that fits you best — takes about 30 seconds.',
+  to: '/?picker=open',
+  destination: 'persona-picker',
+  cta: 'Find my starting point',
+}
+
+/**
+ * Persona-flavored “where to go next” card mounted at the bottom of /about.
+ * Closes audit task P18-P1-02. Renders a generic fallback when no persona is
+ * selected so first-time visitors still get a forward-motion CTA.
+ */
+export function AboutNextStepCTA() {
+  const selectedPersona = usePersonaStore((s) => s.selectedPersona)
+  const spec = selectedPersona ? PERSONA_CTAS[selectedPersona] : DEFAULT_CTA
+
+  return (
+    <div
+      className="glass-panel p-5 md:p-6 flex flex-col md:flex-row gap-4 md:items-center md:justify-between print:hidden"
+      data-section-id="about-next-step"
+    >
+      <div className="flex items-start gap-3 min-w-0">
+        <div className="shrink-0 mt-0.5">{spec.icon}</div>
+        <div className="min-w-0">
+          <h3 className="text-base font-semibold text-foreground">{spec.title}</h3>
+          <p className="text-sm text-muted-foreground mt-1">{spec.body}</p>
+        </div>
+      </div>
+      <Link
+        to={spec.to}
+        onClick={() => logAboutNextStepCta(spec.destination)}
+        className={cn(
+          buttonVariants({ variant: 'gradient', size: 'sm' }),
+          'shrink-0 inline-flex items-center gap-1.5'
+        )}
+      >
+        {spec.cta}
+        <ArrowRight size={14} />
+      </Link>
+    </div>
+  )
+}

--- a/src/components/About/AboutView.tsx
+++ b/src/components/About/AboutView.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import { ReleaseNotesSection } from './sections/ReleaseNotesSection'
 import { VisionSection } from './sections/VisionSection'
 import { TransparencySection } from './sections/TransparencySection'
@@ -15,13 +15,41 @@ import { LicenseSection } from './sections/LicenseSection'
 import { RagAiSection } from './sections/RagAiSection'
 import { CryptoBuffSection } from './sections/CryptoBuffSection'
 import { AppearanceSection } from './sections/AppearanceSection'
+import { AboutNextStepCTA } from './AboutNextStepCTA'
 import { useIsEmbedded } from '../../embed/EmbedProvider'
+import { logAboutOutboundLink } from '@/utils/analytics'
 
 export function AboutView() {
   const isEmbedded = useIsEmbedded()
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  /**
+   * Event-delegated outbound-link logger — closes audit task P18-P1-01.
+   * Attached at the DOM level (not a synthetic onClick on a non-interactive
+   * div, which jsx-a11y blocks) so a single capture-phase listener handles
+   * every outbound `<a>` in the 15 About sub-sections without per-link edits.
+   */
+  useEffect(() => {
+    const node = containerRef.current
+    if (!node) return
+    const handler = (e: MouseEvent) => {
+      const target = (e.target as HTMLElement | null)?.closest('a') as HTMLAnchorElement | null
+      if (!target || !target.href) return
+      try {
+        const url = new URL(target.href, window.location.href)
+        if (url.origin !== window.location.origin) {
+          logAboutOutboundLink(url.href)
+        }
+      } catch {
+        // Malformed href — skip silently
+      }
+    }
+    node.addEventListener('click', handler)
+    return () => node.removeEventListener('click', handler)
+  }, [])
 
   return (
-    <div className="max-w-6xl mx-auto space-y-6 md:space-y-8">
+    <div ref={containerRef} className="max-w-6xl mx-auto space-y-6 md:space-y-8">
       <AboutSection slug="vision">
         <VisionSection />
       </AboutSection>
@@ -78,6 +106,8 @@ export function AboutView() {
           <AppearanceSection />
         </AboutSection>
       )}
+
+      <AboutNextStepCTA />
     </div>
   )
 }

--- a/src/components/Report/ReportContent.tsx
+++ b/src/components/Report/ReportContent.tsx
@@ -45,6 +45,7 @@ import { ReportTimelineStrip } from './ReportTimelineStrip'
 import { ReportThreatsAppendix, ASSESS_TO_THREATS_INDUSTRY } from './ReportThreatsAppendix'
 import { ReportCswp39Nav } from './ReportCswp39Nav'
 import { useThreatsData } from '../../hooks/useThreatsData'
+import { GlossaryAutoWrap } from '../PKILearning/common/GlossaryAutoWrap'
 import { MigrationRoadmap } from './MigrationRoadmap'
 import { MigrationToolkit } from './MigrationToolkit'
 import { ReportMethodologyModal } from './ReportMethodologyModal'
@@ -857,7 +858,13 @@ export const ReportContent: React.FC<AssessReportProps> = ({
                         </p>
                       )}
                       <p className="text-sm text-muted-foreground text-center mt-4 leading-relaxed print:text-muted-foreground">
-                        {result.personaNarrative ?? result.narrative}
+                        {selectedPersona === 'curious' ? (
+                          <GlossaryAutoWrap>
+                            {result.personaNarrative ?? result.narrative}
+                          </GlossaryAutoWrap>
+                        ) : (
+                          (result.personaNarrative ?? result.narrative)
+                        )}
                       </p>
                       {result.boosts &&
                         result.boosts.length > 0 &&

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -165,6 +165,14 @@ export const logExternalLink = (category: string, url: string) => {
   logEvent(category, 'External Link', url)
 }
 
+export const logAboutOutboundLink = (url: string) => {
+  logEvent('About', 'Outbound Link', personaLabel(url))
+}
+
+export const logAboutNextStepCta = (destination: string) => {
+  logEvent('About', 'Next Step CTA', personaLabel(destination))
+}
+
 // --- Patents tracking ---
 
 export const logPatentView = (patentNumber: string) => {


### PR DESCRIPTION
## Summary

Closes the three Phase 1 deferred tasks from \`EXECUTION-PLAN.md §4.1\` that share the renderer-pass infrastructure. P06-P1-04 (the fourth task in the original deferred bucket) was already shipped via \`CuriousSummaryBanner:246+\` — no new code needed there.

| Task | Surface | Change |
|---|---|---|
| **P15-P1-07** | \`/report\` | Glossary auto-link for Curious viewers — \`<GlossaryAutoWrap>\` around the persona narrative when \`selectedPersona === 'curious'\` |
| **P18-P1-01** | \`/about\` | Outbound-link analytics via a single capture-phase listener — catches all 15 outbound \`<a>\` clicks across About sub-sections, fires \`logAboutOutboundLink(url)\` with persona dimension |
| **P18-P1-02** | \`/about\` | New \`AboutNextStepCTA\` card at page bottom — persona-flavored "where to go next" with role-shaped destination |

## Implementation notes

- **Reused existing infrastructure**: \`applyGlossaryToChildren\` (production-tested via \`CuriousSummaryBanner\` + \`GlossaryAutoWrap\` for ~10 PKILearning modules) covers P15-P1-07 with zero new utility code.
- **Single delegated listener** on the AboutView wrapper handles P18-P1-01. Beats touching 15 sub-section files. Attached via \`useEffect\` + \`useRef\` (not a synthetic onClick on a non-interactive div, which jsx-a11y blocks).
- **Two new analytics helpers** in \`src/utils/analytics.ts\`: \`logAboutOutboundLink\` and \`logAboutNextStepCta\`, both routed through the existing \`personaLabel()\` decorator pattern.
- **AboutNextStepCTA** uses \`buttonVariants\` directly on a \`<Link>\` (the Button component doesn't support \`asChild\` in this codebase).

## Test plan

- [x] \`npx tsc -b\` clean
- [x] \`npx eslint <touched files>\` clean (only pre-existing warnings)
- [x] \`CI=true npx vitest run src/components/About/ src/components/Report/ src/utils/analytics.test.ts\` — **77/77 green**
- [ ] CI green on this PR
- [ ] Spot-check \`/about\` bottom card on each persona
- [ ] Spot-check Curious narrative on \`/report\` shows underlined glossary terms

## Scope

This PR only touches what the three tasks need. The two pre-existing local-only test failures (\`useChatSend.test.ts\` env-dependent and \`corpus-trust-invariants.test.ts\` T16 \`describeMaintainerLocal\`) are out of scope — both pass under \`CI=true\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)