### PR TITLE
test(e2e): Playwright coverage for CC-12 + CC-17 + P11-P1-03

### DIFF
--- a/e2e/compliance-focus-view.spec.ts
+++ b/e2e/compliance-focus-view.spec.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0-only
+import { test, expect } from '@playwright/test'
+
+/**
+ * P11-P1-03 — Compliance regulator Focus view.
+ *
+ * Landscape tab → regulations facet → "Focus view" toggle replaces the grid
+ * with a master-detail layout (left rail of frameworks, right pane detail).
+ * Only the `regulations` landscape type is focus-eligible; other facets
+ * (standards / technical / certification) do not surface the toggle.
+ */
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    // Suppress disclaimer + WhatsNew overlays that intercept clicks.
+    localStorage.setItem(
+      'pqc-disclaimer-storage',
+      JSON.stringify({ state: { acknowledgedMajorVersion: 99 }, version: 0 })
+    )
+    localStorage.setItem(
+      'pqc-version-storage',
+      JSON.stringify({ state: { lastSeenVersion: '99.0.0' }, version: 0 })
+    )
+  })
+})
+
+test('toggling Focus view replaces the grid with master-detail', async ({ page }) => {
+  // ?tab=compliance lands on the regulations facet of the landscape tab.
+  await page.goto('/compliance?tab=compliance')
+
+  // The Focus toggle button is only present on the regulations facet.
+  const toggle = page.getByRole('button', { name: /focus view/i }).first()
+  // Compliance is lazy-loaded; allow 15s for the chunk to compile cold.
+  await expect(toggle).toBeVisible({ timeout: 15000 })
+  await toggle.click()
+
+  // FrameworkFocusView renders a section labelled "Framework focus view".
+  await expect(page.getByRole('region', { name: 'Framework focus view' })).toBeVisible()
+
+  // Left-rail nav is labelled "Frameworks".
+  await expect(page.getByRole('navigation', { name: 'Frameworks' })).toBeVisible()
+})
+
+test('Return to framework grid exits Focus view', async ({ page }) => {
+  await page.goto('/compliance?tab=compliance')
+
+  const toggle = page.getByRole('button', { name: /focus view/i }).first()
+  await expect(toggle).toBeVisible({ timeout: 15000 })
+  await toggle.click()
+
+  const back = page.getByRole('button', { name: 'Return to framework grid' })
+  await expect(back).toBeVisible()
+  await back.click()
+
+  // Focus view region gone; toggle reverts to "Focus view" label.
+  await expect(page.getByRole('region', { name: 'Framework focus view' })).not.toBeVisible()
+  await expect(page.getByRole('button', { name: /focus view/i }).first()).toBeVisible()
+})
+
+test('Focus view is not eligible on the standards facet', async ({ page }) => {
+  // ?tab=standards → technical landscape type (not focus-eligible).
+  await page.goto('/compliance?tab=standards')
+
+  // Wait for Compliance to mount before asserting toggle absence.
+  await expect(page.getByRole('main')).toBeVisible({ timeout: 15000 })
+  await expect(page.getByRole('button', { name: /focus view/i })).toHaveCount(0)
+})

--- a/e2e/curious-guide.spec.ts
+++ b/e2e/curious-guide.spec.ts
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-3.0-only
+import { test, expect } from '@playwright/test'
+
+/**
+ * CC-17 — CuriousGuide 4-step floating tour.
+ *
+ * Renders only when:
+ *   - selectedPersona === 'curious'
+ *   - curiousGuideDismissed === false
+ *
+ * Dismissal (via X, Finish, or any CTA) persists across reloads via
+ * usePersonaStore v7 migration field `curiousGuideDismissed`.
+ */
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    // Suppress overlays that would intercept clicks on the floating tour.
+    localStorage.setItem(
+      'pqc-disclaimer-storage',
+      JSON.stringify({ state: { acknowledgedMajorVersion: 99 }, version: 0 })
+    )
+    localStorage.setItem(
+      'pqc-version-storage',
+      JSON.stringify({ state: { lastSeenVersion: '99.0.0' }, version: 0 })
+    )
+    // Curious persona + tour not yet dismissed. Match the v7 store shape.
+    localStorage.setItem(
+      'pqc-learning-persona',
+      JSON.stringify({
+        state: {
+          selectedPersona: 'curious',
+          selectedRegion: 'global',
+          selectedIndustry: null,
+          selectedIndustries: [],
+          experienceLevel: 'curious',
+          viewAccess: 'preview',
+          hasSeenPersonaPicker: true,
+          suppressSuggestion: true,
+          niceTier: 'awareness',
+          niceTierOverridden: false,
+          curiousGuideDismissed: false,
+        },
+        version: 7,
+      })
+    )
+  })
+})
+
+test('renders the 4-step tour and the Finish flow persists dismissal', async ({ page }) => {
+  await page.goto('/')
+
+  const guide = page.getByTestId('curious-guide')
+  // Landing is lazy-loaded; allow 15s for the chunk to compile cold.
+  await expect(guide).toBeVisible({ timeout: 15000 })
+
+  // Step 1
+  await expect(guide.getByText(/Everything's encrypted/)).toBeVisible()
+  await expect(guide.getByText(/Step 1 of 4/)).toBeVisible()
+
+  // Advance to step 2
+  await guide.getByRole('button', { name: /^Next/ }).click()
+  await expect(guide.getByText(/Quantum changes the math/)).toBeVisible()
+  await expect(guide.getByText(/Step 2 of 4/)).toBeVisible()
+
+  // Step 3
+  await guide.getByRole('button', { name: /^Next/ }).click()
+  await expect(guide.getByText(/clock is already ticking/)).toBeVisible()
+
+  // Step 4 — last step shows Finish, not Next
+  await guide.getByRole('button', { name: /^Next/ }).click()
+  await expect(guide.getByText(/Find your starting point/)).toBeVisible()
+  const finishBtn = guide.getByRole('button', { name: /^Finish/ })
+  await expect(finishBtn).toBeVisible()
+
+  // Finish dismisses the tour
+  await finishBtn.click()
+  await expect(guide).not.toBeVisible()
+
+  // Reload — dismissal must persist
+  await page.reload()
+  await expect(page.getByTestId('curious-guide')).not.toBeVisible()
+})
+
+test('X-button dismissal persists across reload', async ({ page }) => {
+  await page.goto('/')
+
+  const guide = page.getByTestId('curious-guide')
+  await expect(guide).toBeVisible({ timeout: 15000 })
+
+  await guide.getByRole('button', { name: 'Dismiss tour' }).click()
+  await expect(guide).not.toBeVisible()
+
+  await page.reload()
+  await expect(page.getByTestId('curious-guide')).not.toBeVisible()
+})
+
+test('does not render for non-curious personas', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'pqc-learning-persona',
+      JSON.stringify({
+        state: {
+          selectedPersona: 'executive',
+          selectedRegion: 'global',
+          experienceLevel: 'expert',
+          viewAccess: 'unlocked',
+          hasSeenPersonaPicker: true,
+          suppressSuggestion: true,
+          niceTier: 'awareness',
+          niceTierOverridden: false,
+          curiousGuideDismissed: false,
+        },
+        version: 7,
+      })
+    )
+  })
+  await page.goto('/')
+  // Wait for Landing to mount before asserting absence — lazy chunk cold-start.
+  await expect(page.getByRole('main')).toBeVisible({ timeout: 15000 })
+  await expect(page.getByTestId('curious-guide')).not.toBeVisible()
+})

--- a/e2e/resume-banner.spec.ts
+++ b/e2e/resume-banner.spec.ts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-3.0-only
+import { test, expect } from '@playwright/test'
+
+/**
+ * CC-12 — ResumeBanner.
+ *
+ * Renders when the user has at least one module with status !== 'not-started'.
+ * Picks the most-recently-visited and shows "Continue {Title}". Dismiss
+ * persists per-route per session via sessionStorage.
+ */
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    // Suppress disclaimer + WhatsNew overlays that intercept clicks.
+    localStorage.setItem(
+      'pqc-disclaimer-storage',
+      JSON.stringify({ state: { acknowledgedMajorVersion: 99 }, version: 0 })
+    )
+    localStorage.setItem(
+      'pqc-version-storage',
+      JSON.stringify({ state: { lastSeenVersion: '99.0.0' }, version: 0 })
+    )
+    // Seed module store with pqc-101 in-progress (most-recent visit).
+    // Schema must satisfy the v14 migrate() guard, but only the fields the
+    // ResumeBanner reads (status, lastVisited) actually matter for selection.
+    localStorage.setItem(
+      'pki-module-storage',
+      JSON.stringify({
+        state: {
+          version: '1.0.0',
+          modules: {
+            'pqc-101': {
+              status: 'in-progress',
+              lastVisited: Date.now(),
+              timeSpent: 60,
+              completedSteps: [],
+              quizScores: {},
+              learnSectionChecks: {},
+            },
+          },
+          activeModuleId: null,
+          completedModuleIds: [],
+          recentActivityLog: [],
+        },
+        version: 14,
+      })
+    )
+  })
+})
+
+test('shows the resume banner when a module is in-progress', async ({ page }) => {
+  await page.goto('/')
+
+  const banner = page.getByRole('link', { name: /^Continue PQC/ })
+  // Landing is lazy-loaded; allow 15s for the chunk to compile cold.
+  await expect(banner).toBeVisible({ timeout: 15000 })
+  // Module title is whatever pqc-101 resolves to in MODULE_CATALOG —
+  // verify the resume affordance is present, not a literal title.
+  await expect(page.getByRole('button', { name: 'Dismiss resume banner' })).toBeVisible()
+})
+
+test('clicking Continue navigates to the module page', async ({ page }) => {
+  await page.goto('/')
+  const banner = page.getByRole('link', { name: /^Continue PQC/ })
+  await expect(banner).toBeVisible({ timeout: 15000 })
+  await banner.click()
+  await expect(page).toHaveURL(/\/learn\/pqc-101/)
+})
+
+test('dismissing the banner hides it for the rest of the session', async ({ page }) => {
+  await page.goto('/')
+
+  const dismiss = page.getByRole('button', { name: 'Dismiss resume banner' })
+  await expect(dismiss).toBeVisible({ timeout: 15000 })
+  await dismiss.click()
+
+  await expect(page.getByRole('link', { name: /^Continue PQC/ })).not.toBeVisible()
+
+  // Reload — sessionStorage persists, so banner should stay hidden.
+  await page.reload()
+  await expect(page.getByRole('link', { name: /^Continue PQC/ })).not.toBeVisible()
+})
+
+test('renders nothing when no module has been visited', async ({ page }) => {
+  await page.addInitScript(() => {
+    // Override the beforeEach seed: empty modules map.
+    localStorage.setItem(
+      'pki-module-storage',
+      JSON.stringify({
+        state: {
+          version: '1.0.0',
+          modules: {},
+          activeModuleId: null,
+          completedModuleIds: [],
+          recentActivityLog: [],
+        },
+        version: 14,
+      })
+    )
+  })
+  await page.goto('/')
+  // Allow Landing to fully mount before asserting absence.
+  await expect(page.getByRole('main')).toBeVisible({ timeout: 15000 })
+  await expect(page.getByRole('link', { name: /^Continue PQC/ })).not.toBeVisible()
+})


### PR DESCRIPTION
## Summary

Closes 3 of the 10 high-value Phase 1 flows that EXECUTION-PLAN §8.4 flagged as shipped without E2E coverage. Each spec drives the real component through its primary interactions and verifies the persistence side-effect — not synthetic stubs.

| Spec | Surface | Flow |
|---|---|---|
| \`e2e/curious-guide.spec.ts\` | CC-17 CuriousGuide tour | 4-step Next walk + Finish dismissal, X-button dismissal, non-curious persona renders nothing |
| \`e2e/resume-banner.spec.ts\` | CC-12 ResumeBanner | "Continue PQC 101" appears + navigates, sessionStorage dismissal survives reload, empty module-store renders nothing |
| \`e2e/compliance-focus-view.spec.ts\` | P11-P1-03 Focus view | Toggle replaces grid with FrameworkFocusView master-detail, Back-to-grid exits, toggle absent on non-regulations facets |

## Notes on the patterns

- All 3 specs seed disclaimer + WhatsNew suppression in \`page.addInitScript\` — matches existing convention in \`e2e/navigation.spec.ts\`.
- First locator per spec uses \`{ timeout: 15000 }\` because Landing/Compliance are lazy routes and the default 5s misses the cold Vite cache.
- Resume-banner locator uses \`/^Continue PQC/\` to disambiguate from the existing "Continue Your Journey" hero CTA on Landing.
- Module-store seed mirrors the v14 schema so the rehydration migrate function doesn't wipe state.

## Test plan

- [x] \`npx tsc -b\` clean
- [x] \`npx eslint e2e/<spec files>\` clean
- [x] \`npx playwright test e2e/{curious-guide,resume-banner,compliance-focus-view}.spec.ts --project=chromium\` — **10/10 green** locally
- [ ] CI green on this PR

## Remaining E2E gap

Per §8.4, 7 flows still uncovered: CC-16 TopThreeActions, P11-P1-07 ValidationGantt, P14-P1-03 BC Focus, P15-P1-02 Report hero, P15-P1-03 Board Pack ZIP, P13-P1-04 persona suggestion, P13-P1-06 Curious 5-Q wizard. Worth a follow-up PR after this lands and the patterns are validated against CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)