### PR TITLE
test(e2e): Playwright coverage for P11-P1-07 + P13-P1-06

### DIFF
--- a/e2e/assess-curious-wizard.spec.ts
+++ b/e2e/assess-curious-wizard.spec.ts
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-3.0-only
+import { test, expect } from '@playwright/test'
+
+/**
+ * P13-P1-06 — Curious 5-question Assess wizard variant.
+ *
+ * When `selectedPersona === 'curious'`, AssessWizard filters ALL_STEPS to
+ * the five highest-signal CURIOUS_STEP_KEYS (industry, country, sensitivity,
+ * compliance, migration). The variant trigger is the persona, NOT
+ * experienceLevel — a developer with experienceLevel='curious' still gets
+ * the full 8-step path.
+ */
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'pqc-disclaimer-storage',
+      JSON.stringify({ state: { acknowledgedMajorVersion: 99 }, version: 0 })
+    )
+    localStorage.setItem(
+      'pqc-version-storage',
+      JSON.stringify({ state: { lastSeenVersion: '99.0.0' }, version: 0 })
+    )
+  })
+})
+
+test('renders the 5-question variant for the curious persona', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'pqc-learning-persona',
+      JSON.stringify({
+        state: {
+          selectedPersona: 'curious',
+          selectedRegion: 'global',
+          experienceLevel: 'curious',
+          viewAccess: 'preview',
+          hasSeenPersonaPicker: true,
+          suppressSuggestion: true,
+          niceTier: 'awareness',
+          niceTierOverridden: false,
+          curiousGuideDismissed: true,
+        },
+        version: 7,
+      })
+    )
+  })
+
+  await page.goto('/assess?mode=quick')
+
+  // Wizard header shows "Step 1 of 5" for the curious variant.
+  // Assess is lazy-loaded; allow 15s for the chunk to compile cold.
+  // Two "Step 1 of 5" spans render — `.sm:hidden` mobile + desktop. .last()
+  // picks the desktop one (visible at Playwright's 1280×720 viewport).
+  await expect(page.getByText(/Step 1 of 5/).last()).toBeVisible({ timeout: 15000 })
+})
+
+test('renders the full 8-question path for non-curious personas', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'pqc-learning-persona',
+      JSON.stringify({
+        state: {
+          selectedPersona: 'executive',
+          selectedRegion: 'global',
+          experienceLevel: 'expert',
+          viewAccess: 'unlocked',
+          hasSeenPersonaPicker: true,
+          suppressSuggestion: true,
+          niceTier: 'awareness',
+          niceTierOverridden: false,
+          curiousGuideDismissed: true,
+        },
+        version: 7,
+      })
+    )
+  })
+
+  await page.goto('/assess?mode=quick')
+
+  // 8-question path — header shows "Step 1 of 8".
+  await expect(page.getByText(/Step 1 of 8/).last()).toBeVisible({ timeout: 15000 })
+})
+
+test('developer + experienceLevel=curious still gets the full 8-question path', async ({
+  page,
+}) => {
+  // P13-P1-06 trigger is selectedPersona === 'curious' specifically — NOT
+  // experienceLevel. This regression-locks that the personaConfig
+  // orthogonality is preserved.
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'pqc-learning-persona',
+      JSON.stringify({
+        state: {
+          selectedPersona: 'developer',
+          selectedRegion: 'global',
+          experienceLevel: 'curious',
+          viewAccess: 'unlocked',
+          hasSeenPersonaPicker: true,
+          suppressSuggestion: true,
+          niceTier: 'awareness',
+          niceTierOverridden: false,
+          curiousGuideDismissed: true,
+        },
+        version: 7,
+      })
+    )
+  })
+
+  await page.goto('/assess?mode=quick')
+
+  // 8-question path — header shows "Step 1 of 8".
+  await expect(page.getByText(/Step 1 of 8/).last()).toBeVisible({ timeout: 15000 })
+})

--- a/e2e/validation-gantt.spec.ts
+++ b/e2e/validation-gantt.spec.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0-only
+import { test, expect } from '@playwright/test'
+
+/**
+ * P11-P1-07 — ValidationGantt deadline timeline.
+ *
+ * Renders on /compliance For-You tab when persona === 'executive' (mounted
+ * by ExecutiveTimelineView between the Regulatory Clock and the framework
+ * tier grid). One horizontal bar per applicable framework with a concrete
+ * deadline year, color-coded by deadline phase.
+ */
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'pqc-disclaimer-storage',
+      JSON.stringify({ state: { acknowledgedMajorVersion: 99 }, version: 0 })
+    )
+    localStorage.setItem(
+      'pqc-version-storage',
+      JSON.stringify({ state: { lastSeenVersion: '99.0.0' }, version: 0 })
+    )
+    // Executive persona + a profile that triggers the For-You executive view
+    // (matches the existing AU exec workshop seed in compliance-foryou-executive.spec.ts).
+    localStorage.setItem(
+      'pqc-learning-persona',
+      JSON.stringify({
+        state: {
+          selectedPersona: 'executive',
+          selectedRegion: 'apac',
+          selectedIndustry: 'Government & Defense',
+          selectedIndustries: ['Government & Defense'],
+          experienceLevel: 'expert',
+          viewAccess: 'unlocked',
+          hasSeenPersonaPicker: true,
+          suppressSuggestion: true,
+          niceTier: 'awareness',
+          niceTierOverridden: false,
+          curiousGuideDismissed: false,
+        },
+        version: 7,
+      })
+    )
+  })
+})
+
+test('renders the Deadline timeline on /compliance executive For-You', async ({ page }) => {
+  await page.goto(
+    '/compliance?tab=foryou&country=Australia&ind=' + encodeURIComponent('Government & Defense')
+  )
+
+  // ValidationGantt is a section with aria-label="Compliance deadline timeline".
+  // Compliance is lazy-loaded; allow 15s for the chunk to compile cold.
+  const gantt = page.getByRole('region', { name: 'Compliance deadline timeline' })
+  await expect(gantt).toBeVisible({ timeout: 15000 })
+
+  // The section header surfaces the count of frameworks with a concrete year.
+  await expect(gantt.getByRole('heading', { name: 'Deadline timeline' })).toBeVisible()
+})
+
+test('renders a framework count summary in the header', async ({ page }) => {
+  await page.goto(
+    '/compliance?tab=foryou&country=Australia&ind=' + encodeURIComponent('Government & Defense')
+  )
+
+  const gantt = page.getByRole('region', { name: 'Compliance deadline timeline' })
+  await expect(gantt).toBeVisible({ timeout: 15000 })
+
+  // The header shows "N framework(s) with a concrete year".
+  await expect(gantt.getByText(/\d+ framework.*with a concrete year/)).toBeVisible()
+})


### PR DESCRIPTION
## Summary

Round 2 of E2E coverage for Phase 1 flows that shipped without Playwright tests (per \`EXECUTION-PLAN.md §8.4\`). Follows #239 (round 1: CC-12 ResumeBanner, CC-17 CuriousGuide, P11-P1-03 Compliance Focus view).

| Spec | Surface | Flow |
|---|---|---|
| \`e2e/validation-gantt.spec.ts\` | P11-P1-07 | Deadline-timeline gantt mounts on /compliance For-You for the executive persona; aria-region + header + framework-count summary all render |
| \`e2e/assess-curious-wizard.spec.ts\` | P13-P1-06 | Curious persona gets the 5-question variant; non-curious personas + developer-with-curious-experience get the full 8-question path |

## Deferred from this round

**P14-P1-03 BC Zone Focus** — attempted, but the Focus toggle is gated behind \`metrics.isFullyEmpty=false\`, which requires deeper assessment-state seeding (both \`pqc-assessment-form\` and \`pqc-assessment-result\` stores). Cleaner as its own focused PR once we have a shared assessment-seed fixture.

## Pattern notes for future Phase 1 spec authors

- \`/assess?mode=quick\` URL param skips ModeSelector and lands directly on the wizard. Use this to avoid clicking through the mode picker.
- Wizard "Step N of M" appears twice in the DOM — a mobile compact version (\`sm:hidden\`) and a desktop one. Use \`.last()\` to pick the desktop one (visible at Playwright's 1280×720 default).
- ValidationGantt renders only when ExecutiveTimelineView mounts (persona=executive + applicable frameworks). Seed both persona AND assessment industry/country.
- 15s timeout on first locator per spec for lazy-route cold compile.

## Test plan

- [x] \`npx tsc -b\` clean
- [x] \`npx prettier --check\` clean (husky pre-commit hook enforced — no \`--no-verify\` this time)
- [x] \`npx playwright test e2e/validation-gantt.spec.ts e2e/assess-curious-wizard.spec.ts --project=chromium\` — **5/5 green** locally
- [ ] CI green on this PR

## Remaining §8.4 gap after this PR

| Task | Surface | Why deferred |
|---|---|---|
| CC-16 TopThreeActions | Report | Needs completed assessment seed |
| P14-P1-03 BC Zone Focus | Business Center | Needs assessment+metrics seed (see above) |
| P15-P1-02 Report hero | Report | Needs completed assessment seed |
| P15-P1-03 Board Pack ZIP | Report | Needs assessment + download-event capture |
| P13-P1-04 Persona suggestion | Report | Needs completed assessment + inferred-persona setup |

A unified "assessment-seeded" PR could batch the 5 remaining flows once we have a shared fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)