### PR TITLE
feat(learn): WorkshopOperationLog progress bar (A7 phase 1)

### DIFF
--- a/src/components/PKILearning/common/WorkshopOperationLog.test.tsx
+++ b/src/components/PKILearning/common/WorkshopOperationLog.test.tsx
@@ -33,4 +33,28 @@ describe('WorkshopOperationLog', () => {
     render(<WorkshopOperationLog entries={entries} />)
     expect(screen.getByText('[432ms]')).toBeInTheDocument()
   })
+
+  it('shows the indeterminate progress bar when any entry is pending', () => {
+    const entries: LogEntry[] = [
+      { status: 'success', message: 'Generated key', durationMs: 12 },
+      { status: 'pending', message: 'Signing...' },
+    ]
+    render(<WorkshopOperationLog entries={entries} />)
+    const bar = screen.getByRole('progressbar', { name: 'Operation in progress' })
+    expect(bar).toBeInTheDocument()
+    // Indeterminate — no aria-valuenow set.
+    expect(bar).not.toHaveAttribute('aria-valuenow')
+    // Log container reports busy state to assistive tech.
+    expect(screen.getByRole('log')).toHaveAttribute('aria-busy', 'true')
+  })
+
+  it('hides the progress bar when no entries are pending', () => {
+    const entries: LogEntry[] = [
+      { status: 'success', message: 'Generated key', durationMs: 12 },
+      { status: 'success', message: 'Signed', durationMs: 87 },
+    ]
+    render(<WorkshopOperationLog entries={entries} />)
+    expect(screen.queryByRole('progressbar', { name: 'Operation in progress' })).toBeNull()
+    expect(screen.getByRole('log')).toHaveAttribute('aria-busy', 'false')
+  })
 })

--- a/src/components/PKILearning/common/WorkshopOperationLog.tsx
+++ b/src/components/PKILearning/common/WorkshopOperationLog.tsx
@@ -19,13 +19,16 @@ interface WorkshopOperationLogProps {
  *
  * Renders a scrollable monospace list of log entries with per-row status
  * icons. Auto-scrolls to the bottom on new entries. Announces changes to
- * screen readers via aria-live="polite".
+ * screen readers via aria-live="polite". When any entry is `pending`, an
+ * indeterminate progress bar runs at the top of the log so users can see
+ * an operation is in flight without reading the per-row icons.
  */
 export const WorkshopOperationLog: React.FC<WorkshopOperationLogProps> = ({
   entries,
   className,
 }) => {
   const bottomRef = useRef<HTMLDivElement>(null)
+  const hasPending = entries.some((e) => e.status === 'pending')
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView?.({ behavior: 'smooth', block: 'nearest' })
@@ -38,11 +41,21 @@ export const WorkshopOperationLog: React.FC<WorkshopOperationLogProps> = ({
       role="log"
       aria-live="polite"
       aria-label="Operation log"
+      aria-busy={hasPending}
       className={clsx(
         'bg-muted rounded-lg p-3 font-mono text-xs max-h-32 overflow-y-auto space-y-1',
         className
       )}
     >
+      {hasPending && (
+        <div
+          className="relative -m-1 mb-1 h-1 overflow-hidden rounded-full bg-primary/20"
+          role="progressbar"
+          aria-label="Operation in progress"
+        >
+          <div className="absolute inset-y-0 left-0 w-1/3 animate-workshop-progress rounded-full bg-primary" />
+        </div>
+      )}
       {entries.map((entry, idx) => (
         <div key={idx} className="flex items-start gap-1.5 min-w-0">
           <span className="shrink-0 mt-px">

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -146,6 +146,20 @@
     animation: pulse-glow 2.5s ease-in-out infinite;
   }
 
+  /* Indeterminate progress bar for WorkshopOperationLog (A7 — async state). */
+  @keyframes workshop-progress {
+    0% {
+      transform: translateX(-100%);
+    }
+    100% {
+      transform: translateX(400%);
+    }
+  }
+
+  .animate-workshop-progress {
+    animation: workshop-progress 1.4s ease-in-out infinite;
+  }
+
   /* Respect user's reduced-motion preference for CSS animations/transitions */
   @media (prefers-reduced-motion: reduce) {
     *,


### PR DESCRIPTION
## Summary

Adds an indeterminate progress bar to \`WorkshopOperationLog\` so users can see crypto operations are running, not just rely on the per-row \`Loader2\` spinner inside the log panel.

Landing at the WorkshopOperationLog level means every component already using the panel — \`EmailSigning\` trio (MLDSASignDemo, MLKEMEncryptDemo, DualSignDemo) + \`PKIEnrollmentProtocols\` sextet (KeyGenStep, CertViewer, EstSimpleEnroll, CmpInitialReq, CmpKemKeyUpdate, CompositeEnroll) — picks it up for free. Every future A7 migration also gets it by default.

## Changes

**\`WorkshopOperationLog.tsx\`**: when any entry has \`status==='pending'\`, renders a 1px indeterminate bar at the top of the log panel. \`aria-busy\` on the container reflects the same state so assistive tech announces the in-progress condition. The bar is a real \`role=\"progressbar\"\` with \`aria-label=\"Operation in progress\"\`.

**\`src/styles/index.css\`**: new \`@keyframes workshop-progress\` translates a 1/3-width segment from −100% to 400% over 1.4s, ease-in-out, infinite. Respects the existing global \`prefers-reduced-motion: reduce\` override (collapses animation-duration to 0.01ms, so reduced-motion users get a static indicator).

**Tests**: 2 new tests verify (a) progressbar appears when any entry is pending, (b) it disappears when all entries resolve, (c) \`aria-busy\` reflects state.

## Context — A7

\`ux-gap-analysis.md\` flagged A7 (HIGH severity, ~50 files) as workshop components showing blank result panes during WASM ops. 9 components have been migrated to the WorkshopOperationLog + ErrorAlert pattern. This PR enhances that shared infrastructure with a more visible progress indicator. The remaining ~40 workshop demos still need to be migrated; that's tracked as follow-up PRs.

## Test plan

- [x] \`npx tsc -b\` clean
- [x] \`npx prettier --check\` clean (husky pre-commit hook enforced)
- [x] \`CI=true npx vitest run src/components/PKILearning/common/\` — **6/6 green** (4 existing + 2 new)
- [x] Existing EmailSigning workshop tests still pass — no API change, just additive rendering
- [ ] CI green on this PR
- [ ] Spot-check the 9 already-wired demos — running a sign / encap / enroll flow should now show the bar at the top of the log while pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)