### PR TITLE
feat(learn): persona-path view + overwhelm reduction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,6 +243,10 @@ scripts/*
 # against the latest Timeline CSV. Pure read-only against public data.
 !scripts/audit-timeline-aliases.ts
 
+# Parallel-session worktree helper — developer tooling, no crypto or data
+# secrets. Documented in CLAUDE.md ("Parallel sessions: use git worktrees").
+!scripts/new-worktree.sh
+
 # Compliance country-token audit — runs in CI. Validates every country/region
 # token in the latest compliance CSV resolves through COUNTRY_CODE_TO_NAME and
 # COUNTRY_TO_REGION in src/data/complianceData.ts. Pure read-only.

--- a/e2e/learn-persona-path.spec.ts
+++ b/e2e/learn-persona-path.spec.ts
@@ -129,4 +129,45 @@ test.describe('Learn — persona-path view', () => {
     })
     await expect(page.getByText(/Browse all \d+ modules/i)).toHaveCount(0)
   })
+
+  test('P2-1: ops persona sees the "Try in playground" affordance on mapped module cards', async ({
+    page,
+  }) => {
+    await seedPersona(page, 'ops')
+    await page.goto('/learn')
+
+    await expect(page.getByText(/Browse all \d+ modules/i).first()).toBeVisible({
+      timeout: 25000,
+    })
+    // Open every persona-path phase so the mapped module cards (and their
+    // "Try in playground" buttons) become visible in the accessibility tree.
+    await page.evaluate(() => {
+      document
+        .querySelectorAll<HTMLDetailsElement>('section[aria-label="Your curated learning path"] details')
+        .forEach((d) => {
+          d.open = true
+        })
+    })
+    await expect(
+      page.getByRole('button', { name: /Try in playground/i }).first()
+    ).toBeVisible({ timeout: 10000 })
+  })
+
+  test('P2-3: researcher persona sees the algorithm/standard taxonomy filter above stack', async ({
+    page,
+  }) => {
+    await seedPersona(page, 'researcher')
+    await page.goto('/learn')
+
+    const region = page.getByRole('region', {
+      name: /Researcher: browse modules by algorithm or standard/i,
+    })
+    await expect(region).toBeVisible({ timeout: 25000 })
+    // The two top-level chips are scoped inside the taxonomy region so they
+    // don't collide with the global "Algorithms view" nav button.
+    await region.getByRole('button', { name: 'Algorithm', exact: true }).click()
+    await expect(page.getByRole('listbox', { name: /Algorithms/i })).toBeVisible()
+    // ML-KEM option is one of the curated taxons
+    await expect(page.getByRole('option', { name: /ML-KEM/ })).toBeVisible()
+  })
 })

--- a/e2e/learn-persona-path.spec.ts
+++ b/e2e/learn-persona-path.spec.ts
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: GPL-3.0-only
+import { test, expect, type Page } from '@playwright/test'
+
+/**
+ * P0-P1 — Learn hub persona-path view.
+ *
+ * Verifies the persona-overwhelm plan: every persona except researcher lands
+ * on a curated `'path'` view above the fold; the catalog is one click behind
+ * `<details>`; curious is no longer force-filtered to 'All'.
+ */
+
+type PersonaId = 'executive' | 'developer' | 'architect' | 'researcher' | 'ops' | 'curious'
+
+const seedPersona = async (page: Page, persona: PersonaId | null) => {
+  await page.addInitScript(
+    ([p]) => {
+      // Suppress WhatsNew modal that intercepts clicks (per CLAUDE.md E2E protocol).
+      localStorage.setItem(
+        'pqc-version-storage',
+        JSON.stringify({ state: { lastSeenVersion: '99.0.0' }, version: 0 })
+      )
+      localStorage.setItem(
+        'pqc-disclaimer-storage',
+        JSON.stringify({ state: { acknowledgedMajorVersion: 99 }, version: 0 })
+      )
+      // Suppress the GuidedTour overlay (it blocks the page on first visit).
+      localStorage.setItem('pqc-tour-completed', 'true')
+      if (p !== null) {
+        localStorage.setItem(
+          'pqc-learning-persona',
+          JSON.stringify({
+            state: {
+              selectedPersona: p,
+              selectedRegion: 'global',
+              experienceLevel: p === 'curious' ? 'curious' : null,
+              viewAccess: 'preview',
+              hasSeenPersonaPicker: true,
+              suppressSuggestion: true,
+              niceTier: 'awareness',
+              niceTierOverridden: false,
+              curiousGuideDismissed: true,
+            },
+            version: 7,
+          })
+        )
+      }
+      // Reset the curious-escape so each test starts on the curated path.
+      localStorage.setItem(
+        'pqc-learn-storage',
+        JSON.stringify({
+          state: { showEverything: false, phaseExpansion: {}, researcherSortOverride: null },
+          version: 1,
+        })
+      )
+    },
+    [persona]
+  )
+}
+
+test.describe('Learn — persona-path view', () => {
+  for (const persona of ['executive', 'developer', 'architect', 'ops'] as const) {
+    test(`${persona} lands on the curated path with phase boundaries`, async ({ page }) => {
+      await seedPersona(page, persona)
+      await page.goto('/learn')
+
+      // Path view exposes the "Browse all" details element. Stack-mode pages don't.
+      // The hub is lazy-loaded; allow ample budget for the chunk to compile cold
+      // (~6-8s observed for executive).
+      await expect(
+        page.getByText(/Browse all \d+ modules \(\d+ tracks\)/i).first()
+      ).toBeVisible({ timeout: 25000 })
+
+      // Catalog is collapsed behind <details> by default
+      const details = page.locator('details').filter({
+        hasText: /Browse all \d+ modules/i,
+      })
+      await expect(details).toHaveCount(1)
+    })
+  }
+
+  test('curious lands on the curated path (NOT the unfiltered catalog) — P0-1 regression guard', async ({
+    page,
+  }) => {
+    await seedPersona(page, 'curious')
+    await page.goto('/learn')
+
+    // Same affordance as the other personas — proves selectedPersonaFilter is
+    // 'curious', not 'All'.
+    await expect(page.getByText(/Browse all \d+ modules/i).first()).toBeVisible({
+      timeout: 25000,
+    })
+
+    // The curious "Show me everything (advanced)" escape is present.
+    await expect(page.getByRole('button', { name: /Show me everything/i })).toBeVisible()
+  })
+
+  test('curious "Show me everything" reveals the stack catalog', async ({ page }) => {
+    await seedPersona(page, 'curious')
+    await page.goto('/learn')
+
+    // Wait for path view to mount before clicking the escape.
+    await expect(
+      page.getByRole('button', { name: /Show me everything/i })
+    ).toBeVisible({ timeout: 25000 })
+    await page.getByRole('button', { name: /Show me everything/i }).click()
+
+    // After the escape, the curated banner / Browse-all details element should
+    // be gone (viewMode flipped to 'stack').
+    await expect(page.getByText(/Browse all \d+ modules/i)).toHaveCount(0)
+  })
+
+  test('researcher stays on stack mode — PersonaPathView NOT rendered', async ({ page }) => {
+    await seedPersona(page, 'researcher')
+    await page.goto('/learn')
+
+    // Wait for the hub h1 to settle so we know lazy-load is done.
+    await expect(page.getByRole('heading', { level: 1, name: /Learning Workshops/i })).toBeVisible({
+      timeout: 25000,
+    })
+    await expect(page.getByText(/Browse all \d+ modules/i)).toHaveCount(0)
+  })
+
+  test('null persona keeps stack default — no regression', async ({ page }) => {
+    await seedPersona(page, null)
+    await page.goto('/learn')
+
+    await expect(page.getByRole('heading', { level: 1, name: /Learning Workshops/i })).toBeVisible({
+      timeout: 25000,
+    })
+    await expect(page.getByText(/Browse all \d+ modules/i)).toHaveCount(0)
+  })
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,10 @@
 import { defineConfig, devices } from '@playwright/test'
 
+// Port can be overridden via PLAYWRIGHT_DEV_PORT for parallel worktrees that
+// can't all bind 5175 (see CLAUDE.md "Parallel sessions: use git worktrees").
+const DEV_PORT = parseInt(process.env.PLAYWRIGHT_DEV_PORT ?? '5175', 10)
+const BASE_URL = `http://localhost:${DEV_PORT}`
+
 export default defineConfig({
   testDir: './e2e',
   timeout: 30 * 1000,
@@ -14,7 +19,7 @@ export default defineConfig({
   use: {
     actionTimeout: 0,
     trace: 'on-first-retry',
-    baseURL: 'http://localhost:5175',
+    baseURL: BASE_URL,
   },
   projects: [
     {
@@ -23,8 +28,8 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'npm run dev',
-    port: 5175,
+    command: `npm run dev -- --port ${DEV_PORT} --strictPort`,
+    port: DEV_PORT,
     reuseExistingServer: !process.env.CI,
     timeout: 30000,
   },

--- a/reports/trust-tier-snapshot.json
+++ b/reports/trust-tier-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "measuredAt": "2026-05-22T15:44:44.890Z",
+  "measuredAt": "2026-05-22T19:05:30.592Z",
   "note": "Pre-SME-triage baseline for Phase 2 acceptance — re-run after admin-portal queues land to compare.",
   "overall": {
     "Authoritative": 88,

--- a/scripts/new-worktree.sh
+++ b/scripts/new-worktree.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# scripts/new-worktree.sh — create an isolated parallel-session worktree
+#
+# Why this exists:
+#   Git keeps ONE working tree per repository. Two Claude Code sessions opened
+#   in the same `pqctoday-hub` directory share both the disk and the HEAD
+#   pointer — when one session runs `git checkout`, every other session's
+#   files swap with it and their next `git commit` can land on the wrong
+#   branch. Different *pages* don't help; different *physical directories* do.
+#
+# What this does:
+#   Creates a sibling worktree at `${PARENT}/pqctoday-hub-${slug}` pointing at
+#   the requested branch (creating the branch off `origin/main` if it doesn't
+#   exist yet). Symlinks the gitignored project-config files (CLAUDE.md,
+#   .claude/, .cursorrules, sync-private.sh, tasks/) into the new worktree so
+#   a fresh Claude Code session opened there inherits the same rules and
+#   tooling. node_modules is NOT symlinked — run `npm ci` in the new worktree.
+#
+# Usage:
+#   ./scripts/new-worktree.sh <branch>
+#   ./scripts/new-worktree.sh feat/learn-persona-path
+#   ./scripts/new-worktree.sh compliance/persona-overwhelm-p0
+#
+# Slug:
+#   The directory suffix is derived from the part after the last `/` in the
+#   branch name, lowercased, with non-alphanumerics replaced by `-`. So
+#   `feat/learn-persona-path` -> `pqctoday-hub-learn-persona-path`.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <branch-name>" >&2
+  echo "Example: $0 feat/learn-persona-path" >&2
+  exit 2
+fi
+
+BRANCH="$1"
+SRC="$(cd "$(dirname "$0")/.." && pwd)"
+PARENT="$(cd "${SRC}/.." && pwd)"
+
+# Derive a filesystem-safe slug from the part after the last `/`
+SLUG="${BRANCH##*/}"
+SLUG="$(echo "$SLUG" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g')"
+TARGET="${PARENT}/pqctoday-hub-${SLUG}"
+
+if [[ -e "$TARGET" ]]; then
+  echo "Target already exists: $TARGET" >&2
+  echo "If this is the worktree you want, just \`cd $TARGET\` and continue." >&2
+  exit 1
+fi
+
+cd "$SRC"
+
+# Fetch so we can branch off the freshest origin/main if the branch is new
+git fetch --quiet origin || true
+
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  echo "Branch $BRANCH exists locally — checking it out in the new worktree."
+  git worktree add "$TARGET" "$BRANCH"
+elif git show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
+  echo "Branch $BRANCH exists on origin — checking out a local copy in the new worktree."
+  git worktree add -b "$BRANCH" "$TARGET" "origin/$BRANCH"
+else
+  echo "Branch $BRANCH does not exist — creating it from origin/main in the new worktree."
+  git worktree add -b "$BRANCH" "$TARGET" "origin/main"
+fi
+
+# Symlink gitignored project-config files so the new worktree behaves like
+# the main one for Claude Code sessions and the private-sync workflow.
+# We use symlinks (not copies) so updates propagate without rsync.
+link_if_present() {
+  local name="$1"
+  if [[ -e "${SRC}/${name}" && ! -e "${TARGET}/${name}" ]]; then
+    ln -s "${SRC}/${name}" "${TARGET}/${name}"
+    echo "  linked ${name}"
+  fi
+}
+
+echo "Linking private project-config files into ${TARGET}:"
+link_if_present "CLAUDE.md"
+link_if_present ".claude"
+link_if_present ".cursorrules"
+link_if_present "sync-private.sh"
+link_if_present "tasks"
+
+# node_modules is intentionally NOT symlinked — Vite + pnpm/npm can behave
+# strangely with shared node_modules across worktrees, and the new worktree
+# may target a branch that bumps deps. Run `npm ci` in the new worktree.
+
+cat <<EOF
+
+Worktree ready.
+
+  Branch:    $BRANCH
+  Path:      $TARGET
+
+Next steps:
+  cd "$TARGET"
+  npm ci                         # install deps for this worktree (one-time)
+  # ...edit, commit, push as usual — fully isolated from $SRC
+
+To remove this worktree when done:
+  git worktree remove "$TARGET"
+
+EOF

--- a/src/components/PKILearning/Dashboard.test.tsx
+++ b/src/components/PKILearning/Dashboard.test.tsx
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// Integration tests for the Learn hub Dashboard — the persona-overwhelm plan's
+// §Tests Integration five regression cases. These guard the load-bearing fixes:
+//   P0-1  curious is no longer forced to selectedPersonaFilter === 'All'
+//   P0-2  viewMode defaults to 'path' for every persona except researcher / null
+//   P0-3  the curious "Show me everything" escape flips state correctly
+//   P1-2  sort is not silently disabled when a persona is active; "Curated
+//         order" badge appears in its place
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import '@testing-library/jest-dom'
+import { Dashboard } from './Dashboard'
+import { usePersonaStore } from '../../store/usePersonaStore'
+import { useLearnStore } from '../../store/useLearnStore'
+import { useModuleStore } from '../../store/useModuleStore'
+import { EmbedProvider } from '../../embed/EmbedProvider'
+import type { PersonaId } from '@/data/learningPersonas'
+
+const renderDashboard = () =>
+  render(
+    <EmbedProvider>
+      <MemoryRouter initialEntries={['/learn']}>
+        <Dashboard />
+      </MemoryRouter>
+    </EmbedProvider>
+  )
+
+const seedPersona = (personaId: PersonaId | null, extras: Partial<Record<string, unknown>> = {}) => {
+  usePersonaStore.setState({
+    selectedPersona: personaId,
+    selectedRegion: 'global',
+    experienceLevel: personaId === 'curious' ? 'curious' : null,
+    hasSeenPersonaPicker: true,
+    suppressSuggestion: true,
+    niceTier: 'awareness',
+    niceTierOverridden: false,
+    ...extras,
+  })
+}
+
+describe('Dashboard — persona-path integration', () => {
+  beforeEach(() => {
+    useLearnStore.getState().reset()
+    useModuleStore.setState({ modules: {} })
+    localStorage.clear()
+  })
+
+  it('P0-2: executive lands on path view with the curated phases above the catalog', () => {
+    seedPersona('executive')
+    renderDashboard()
+
+    // Path view exposes the "Browse all" disclosure; stack-mode pages don't.
+    expect(screen.getByText(/Browse all \d+ modules \(\d+ tracks\)/i)).toBeInTheDocument()
+    // PersonaPathView mounts the curated section.
+    expect(
+      screen.getByRole('region', { name: /Your curated learning path/i })
+    ).toBeInTheDocument()
+    // The 'Path' chip in the view toggle is the active radio.
+    expect(screen.getByRole('radio', { name: /^Path/i })).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('P0-1 regression: curious starts pre-filtered to its own path (NOT "All")', () => {
+    seedPersona('curious')
+    renderDashboard()
+
+    // Same disclosure as the other personas — proves the curious user is no longer
+    // dumped into the 55-module catalog by the old override in Dashboard.tsx:661-663.
+    expect(screen.getByText(/Browse all \d+ modules/i)).toBeInTheDocument()
+    // The curious-only escape button is present.
+    expect(
+      screen.getByRole('button', { name: /Show me everything \(advanced\)/i })
+    ).toBeInTheDocument()
+  })
+
+  it('P0-2: researcher stays on stack mode — PersonaPathView is NOT rendered', () => {
+    seedPersona('researcher')
+    renderDashboard()
+
+    expect(
+      screen.queryByRole('region', { name: /Your curated learning path/i })
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText(/Browse all \d+ modules/i)).not.toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: /^Stack/i })).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('P0-3: the curious "Show me everything" escape flips to stack and clears persona filter', async () => {
+    const user = userEvent.setup()
+    seedPersona('curious')
+    renderDashboard()
+
+    await user.click(screen.getByRole('button', { name: /Show me everything \(advanced\)/i }))
+
+    // After the escape: PersonaPathView gone, viewMode === 'stack', and the
+    // useLearnStore.showEverything flag is set so a returning curious user
+    // keeps the catalog they opted into.
+    expect(
+      screen.queryByRole('region', { name: /Your curated learning path/i })
+    ).not.toBeInTheDocument()
+    expect(useLearnStore.getState().showEverything).toBe(true)
+    expect(usePersonaStore.getState().selectedPersona).toBeNull()
+  })
+
+  it('P1-2 regression: persona-active path renders the "Curated order" badge instead of silently disabling sort', () => {
+    seedPersona('developer')
+    renderDashboard()
+
+    // Per the plan: "Curated order" badge sits next to the Sort/View controls
+    // when personaFilterActive AND sortBy === 'default'. The badge text is the
+    // exact "Curated order" string we render.
+    expect(screen.getByText(/Curated order/i)).toBeInTheDocument()
+  })
+})

--- a/src/components/PKILearning/Dashboard.tsx
+++ b/src/components/PKILearning/Dashboard.tsx
@@ -35,6 +35,10 @@ import { ModuleCard } from './ModuleCard'
 import { LearnViewToggle, type LearnViewMode } from './LearnViewToggle'
 import { LearnTrackStack } from './LearnTrackStack'
 import { ModuleTable, type ModuleTableItem } from './ModuleTable'
+import { PersonaPathView } from './PersonaPathView'
+import { RecommendedPathBanner } from './RecommendedPathBanner'
+import { usePersonaPathItems } from './usePersonaPathItems'
+import { useLearnStore } from '../../store/useLearnStore'
 import {
   MODULE_CATALOG,
   MODULE_TRACKS,
@@ -460,6 +464,10 @@ export const Dashboard: React.FC = () => {
   const isEmbedded = useIsEmbedded()
   const reduced = usePrefersReducedMotion()
   const { modules } = useModuleStore()
+  // When path view is active for executive/curious, the persona's curated path already
+  // surfaces the common-ground modules with a badge — the standalone callout would
+  // duplicate them. Suppress the callout in that case; keep it for null persona.
+  const showEverything = useLearnStore((s) => s.showEverything)
 
   const activeModules = MODULE_TRACKS.flatMap((t) => t.modules)
 
@@ -550,12 +558,15 @@ export const Dashboard: React.FC = () => {
         />
       )}
 
-      {/* Common Ground callout — for executive, curious, or no-persona users */}
+      {/* Common Ground callout — shown only when path view ISN'T already surfacing these
+          modules. For executive/curious in default (non-showEverything) mode, PersonaPathView
+          renders the same five modules with a "Common Ground" badge, so the standalone
+          callout would duplicate them. Keep the callout for null persona (no path to show). */}
       {!isEmbedded &&
         (selectedPersona === null ||
           selectedPersona === undefined ||
-          selectedPersona === 'executive' ||
-          selectedPersona === 'curious') && (
+          ((selectedPersona === 'executive' || selectedPersona === 'curious') &&
+            showEverything)) && (
           <motion.div
             initial={{ opacity: 0, y: reduced ? 0 : -8 }}
             animate={{ opacity: 1, y: 0 }}
@@ -656,13 +667,38 @@ const ModuleTracksGrid = ({
   const [selectedTrack, setSelectedTrack] = useState(initialTrack)
   const [selectedDifficulty, setSelectedDifficulty] = useState('All')
   const [selectedStatus, setSelectedStatus] = useState('All')
-  // Professional personas pre-select their learning path; curious users start with all modules visible to explore, but advanced topics are guarded in the carousel.
   // ?persona= URL param wins over the persona store on initial mount so chatbot deep links land precisely.
+  // Every persona — including curious — starts pre-filtered to its own curated path. The
+  // "Show me everything (advanced)" escape inside PersonaPathView resets this back to 'All'.
+  const effectivePersona: string | null = initialPersona ?? selectedPersona ?? null
   const [selectedPersonaFilter, setSelectedPersonaFilter] = useState<string>(
-    initialPersona ?? (selectedPersona === 'curious' ? 'All' : (selectedPersona ?? 'All'))
+    effectivePersona ?? 'All'
   )
-  const [sortBy, setSortBy] = useState<LearnSortMode>('default')
-  const [viewMode, setViewMode] = useState<LearnViewMode>('stack')
+  const showEverything = useLearnStore((s) => s.showEverything)
+  const setShowEverything = useLearnStore((s) => s.setShowEverything)
+  const researcherSortOverride = useLearnStore((s) => s.researcherSortOverride)
+  const setResearcherSortOverride = useLearnStore((s) => s.setResearcherSortOverride)
+  // Researcher: default to 'recently' so they land on the freshest content.
+  // showEverything (curious escape) wins over the persona-derived sort if engaged.
+  const initialSort: LearnSortMode = (() => {
+    if (showEverything) return 'default'
+    if (effectivePersona === 'researcher') {
+      return (researcherSortOverride as LearnSortMode) ?? 'recently'
+    }
+    return 'default'
+  })()
+  const [sortBy, setSortBy] = useState<LearnSortMode>(initialSort)
+  // viewMode default depends on the effective persona:
+  //  - researcher / null persona → 'stack' (navigation, not curation)
+  //  - showEverything engaged (curious only) → 'stack'
+  //  - every other persona → 'path' (their curated, phased view)
+  const initialViewMode: LearnViewMode = (() => {
+    if (showEverything) return 'stack'
+    if (!effectivePersona) return 'stack'
+    if (effectivePersona === 'researcher') return 'stack'
+    return 'path'
+  })()
+  const [viewMode, setViewMode] = useState<LearnViewMode>(initialViewMode)
   // Pre-populate from store only when user has explicitly overridden the tier
   const [selectedNiceTier, setSelectedNiceTier] = useState<NiceProficiencyTier | 'All'>(
     niceTierOverridden ? storeNiceTier : 'All'
@@ -678,6 +714,14 @@ const ModuleTracksGrid = ({
     const timer = setTimeout(() => setDebouncedSearch(searchText), 150)
     return () => clearTimeout(timer)
   }, [searchText])
+
+  // Persist researcher sort selection across sessions so changing persona to researcher
+  // doesn't lose their chosen sort. Only writes when researcher is the active persona.
+  useEffect(() => {
+    if (selectedPersona === 'researcher') {
+      setResearcherSortOverride(sortBy)
+    }
+  }, [selectedPersona, sortBy, setResearcherSortOverride])
 
   // Dropdown → store: changing role in the grid updates the persona store
   const handlePersonaFilterChange = useCallback(
@@ -739,33 +783,16 @@ const ModuleTracksGrid = ({
     setSortBy('default')
   }
 
-  // Build flat item list (for Cards and Table modes)
+  // Build flat item list (for Cards and Table modes). When a persona filter is active,
+  // delegate to the shared usePersonaPathItems helper so PersonaPathView and the
+  // cards/table renderers consume the same flat shape (Risk #2 in the plan).
+  const personaPathSummary = usePersonaPathItems(personaFilterActive ? selectedPersonaFilter : null)
   const flatItems = useMemo<ModuleTableItem[]>(() => {
-    if (personaFilterActive) {
-      const persona = PERSONAS[selectedPersonaFilter as PersonaId]
-      if (!persona) return []
-      return persona.pathItems.map((item) => {
-        if (item.type === 'module') {
-          const mod = MODULE_CATALOG[item.moduleId]
-          return {
-            kind: 'module' as const,
-            module: mod,
-            track: MODULE_TO_TRACK[item.moduleId] ?? '',
-          }
-        }
-        return {
-          kind: 'checkpoint' as const,
-          id: item.id,
-          label: item.label,
-          categoryCount: item.categories.length,
-          categories: item.categories,
-        }
-      })
-    }
+    if (personaPathSummary) return personaPathSummary.flatItems
     return MODULE_TRACKS.flatMap(({ track, modules: mods }) =>
       mods.map((module) => ({ kind: 'module' as const, module, track }))
     )
-  }, [personaFilterActive, selectedPersonaFilter])
+  }, [personaPathSummary])
 
   // Apply filters and sort to module items
   const filteredItems = useMemo<ModuleTableItem[]>(() => {
@@ -911,10 +938,15 @@ const ModuleTracksGrid = ({
     [navigate]
   )
 
-  // In stack mode, Track filter is hidden (the stack itself is the track navigator)
-  const showTrackFilter = viewMode !== 'stack'
-  // Sort is disabled in stack mode and when persona filter active
-  const sortDisabled = viewMode === 'stack' || personaFilterActive
+  // In stack/path mode, Track filter is hidden (the stack itself is the track navigator;
+  // path mode renders its own checkpoint-bounded phases).
+  const showTrackFilter = viewMode !== 'stack' && viewMode !== 'path'
+  // Sort is meaningless in stack/path modes (their own ordering is intrinsic).
+  // For cards/table with a persona filter active, sort is allowed but a "Curated order"
+  // badge advertises the default so a custom sort is an explicit user choice.
+  const sortDisabled = viewMode === 'stack' || viewMode === 'path'
+  const curatedOrderActive = personaFilterActive && sortBy === 'default'
+  const sortChangedFromCurated = personaFilterActive && sortBy !== 'default'
 
   let activeFilterCount = 0
   if (selectedTrack !== 'All') activeFilterCount++
@@ -1086,7 +1118,11 @@ const ModuleTracksGrid = ({
                 </div>
                 <div className="space-y-2 flex flex-col pt-4 border-t border-border/50">
                   <span className="text-sm font-semibold text-foreground">View Mode</span>
-                  <LearnViewToggle mode={viewMode} onChange={setViewMode} />
+                  <LearnViewToggle
+                    mode={viewMode}
+                    onChange={setViewMode}
+                    pathAvailable={personaFilterActive}
+                  />
                 </div>
               </div>
             }
@@ -1154,8 +1190,33 @@ const ModuleTracksGrid = ({
           </Button>
         )}
 
+        {/* Curated-order badge — shown when a persona path is active and sort is the
+            persona's curated default. Replaces the silent sort-disable per P1-2. */}
+        {curatedOrderActive && (
+          <span
+            className="text-[10px] font-semibold uppercase tracking-wider text-secondary border border-secondary/30 bg-secondary/10 rounded-full px-2 py-1"
+            title="Sort follows the curated learning order for this persona"
+          >
+            Curated order
+          </span>
+        )}
+        {sortChangedFromCurated && (
+          <Button
+            variant="link"
+            size="sm"
+            onClick={() => setSortBy('default')}
+            className="text-xs"
+          >
+            Reset to curated
+          </Button>
+        )}
+
         {/* View toggle */}
-        <LearnViewToggle mode={viewMode} onChange={setViewMode} />
+        <LearnViewToggle
+                    mode={viewMode}
+                    onChange={setViewMode}
+                    pathAvailable={personaFilterActive}
+                  />
       </div>
 
       {/* Results count + clear (only in cards/table modes or when filters active in stack) */}
@@ -1191,6 +1252,49 @@ const ModuleTracksGrid = ({
           description="Try adjusting the search text or filter criteria."
           action={{ label: 'Clear filters', onClick: clearFilters }}
         />
+      )}
+
+      {/* ── Path mode (persona-curated phases) ── */}
+      {viewMode === 'path' && personaFilterActive && (
+        <div className="space-y-4">
+          {!isEmbedded && (
+            <RecommendedPathBanner
+              personaId={selectedPersonaFilter as PersonaId}
+              onResume={(id) => navigate(id)}
+            />
+          )}
+          <PersonaPathView
+            personaId={selectedPersonaFilter as PersonaId}
+            onSelectModule={(id) => {
+              logEvent('Learning', 'Path Module Click', personaLabel(id))
+              navigate(id)
+            }}
+            isModuleRelevant={isModuleRelevant}
+            isModuleAboveLevel={isModuleAboveLevel}
+            onShowEverything={() => {
+              setShowEverything(true)
+              setViewMode('stack')
+              setSelectedPersonaFilter('All')
+              setPersona(null)
+            }}
+          />
+          <details className="group">
+            <summary className="cursor-pointer text-sm font-medium text-muted-foreground hover:text-foreground transition-colors px-4 py-2 inline-flex items-center gap-2">
+              <span className="text-xs">▸</span>
+              Browse all {totalModuleCount} modules ({MODULE_TRACKS.length} tracks)
+            </summary>
+            <div className="mt-3">
+              <LearnTrackStack
+                navigate={navigate}
+                navigateToQuiz={navigateToQuiz}
+                filteredModuleIds={filteredModuleIds}
+                isModuleRelevant={isModuleRelevant}
+                isModuleAboveLevel={isModuleAboveLevel}
+                onClearFilters={clearFilters}
+              />
+            </div>
+          </details>
+        </div>
       )}
 
       {/* ── Stack mode ── */}
@@ -1300,7 +1404,7 @@ const ModuleTracksGrid = ({
         domain="module"
         limit={5}
         title="Module Content Updates"
-        defaultCollapsed={true}
+        defaultCollapsed={selectedPersona !== 'researcher'}
       />
     </div>
   )

--- a/src/components/PKILearning/Dashboard.tsx
+++ b/src/components/PKILearning/Dashboard.tsx
@@ -38,6 +38,11 @@ import { ModuleTable, type ModuleTableItem } from './ModuleTable'
 import { PersonaPathView } from './PersonaPathView'
 import { RecommendedPathBanner } from './RecommendedPathBanner'
 import { usePersonaPathItems } from './usePersonaPathItems'
+import {
+  ResearcherTaxonomyFilter,
+  type TaxonomySelection,
+} from './ResearcherTaxonomyFilter'
+import { modulesByAlgorithm, modulesByStandard } from './moduleEnrichment'
 import { useLearnStore } from '../../store/useLearnStore'
 import {
   MODULE_CATALOG,
@@ -728,6 +733,13 @@ const ModuleTracksGrid = ({
   // default; reveal under an "Advanced filters" toggle so power users can still
   // engage it without surfacing the chrome on first paint.
   const [advancedFiltersOpen, setAdvancedFiltersOpen] = useState(false)
+  // P2-3: researcher-only secondary axis — browse by algorithm or standard.
+  // Selection narrows the filteredModuleIds set further; null means no extra
+  // filtering. Only applied when persona is researcher AND viewMode is stack.
+  const [taxonomySelection, setTaxonomySelection] = useState<TaxonomySelection>({
+    algorithm: null,
+    standard: null,
+  })
 
   // Show Curious Explorer path in curious mode (persona or experience level); professionals see professional roles
   const isCuriousMode = selectedPersona === 'curious' || experienceLevel === 'curious'
@@ -948,6 +960,18 @@ const ModuleTracksGrid = ({
             !modulePassesTierFilter(m.id, selectedNiceTier as NiceProficiencyTier)
           )
             return false
+          // P2-3: researcher-only taxonomy axis. When an algorithm or standard
+          // is selected, only modules tagged with that taxon survive.
+          if (selectedPersona === 'researcher') {
+            if (taxonomySelection.algorithm) {
+              const matching = modulesByAlgorithm(taxonomySelection.algorithm)
+              if (!matching.includes(m.id)) return false
+            }
+            if (taxonomySelection.standard) {
+              const matching = modulesByStandard(taxonomySelection.standard)
+              if (!matching.includes(m.id)) return false
+            }
+          }
           return true
         })
         .map((m) => m.id)
@@ -960,6 +984,8 @@ const ModuleTracksGrid = ({
     selectedNiceTier,
     personaFilterActive,
     selectedPersonaFilter,
+    selectedPersona,
+    taxonomySelection,
     allModules,
     modules,
     showOnlyLearnModules,
@@ -1358,14 +1384,24 @@ const ModuleTracksGrid = ({
 
       {/* ── Stack mode ── */}
       {viewMode === 'stack' && (
-        <LearnTrackStack
-          navigate={navigate}
-          navigateToQuiz={navigateToQuiz}
-          filteredModuleIds={filteredModuleIds}
-          isModuleRelevant={isModuleRelevant}
-          isModuleAboveLevel={isModuleAboveLevel}
-          onClearFilters={clearFilters}
-        />
+        <>
+          {/* P2-3: researcher 2nd-axis — browse modules by algorithm or standard.
+              Filter narrows filteredModuleIds via the predicate above. */}
+          {selectedPersona === 'researcher' && (
+            <ResearcherTaxonomyFilter
+              selection={taxonomySelection}
+              onChange={setTaxonomySelection}
+            />
+          )}
+          <LearnTrackStack
+            navigate={navigate}
+            navigateToQuiz={navigateToQuiz}
+            filteredModuleIds={filteredModuleIds}
+            isModuleRelevant={isModuleRelevant}
+            isModuleAboveLevel={isModuleAboveLevel}
+            onClearFilters={clearFilters}
+          />
+        </>
       )}
 
       {/* ── Cards mode ── */}

--- a/src/components/PKILearning/Dashboard.tsx
+++ b/src/components/PKILearning/Dashboard.tsx
@@ -43,7 +43,6 @@ import {
   MODULE_CATALOG,
   MODULE_TRACKS,
   MODULE_STEP_COUNTS,
-  MODULE_TO_TRACK,
   LEARN_SECTIONS,
   WORKSHOP_STEPS,
 } from './moduleData'
@@ -723,13 +722,27 @@ const ModuleTracksGrid = ({
     }
   }, [selectedPersona, sortBy, setResearcherSortOverride])
 
-  // Dropdown → store: changing role in the grid updates the persona store
+  // Dropdown → store: changing role in the grid updates the persona store.
+  // When the user re-selects curious from the role pill, we explicitly reset the
+  // "Show me everything" escape so they return to their curated path (plan P0-3
+  // re-entry requirement). Selecting any non-curious persona also clears the
+  // escape since it only ever applied to curious.
   const handlePersonaFilterChange = useCallback(
     (id: string) => {
       setSelectedPersonaFilter(id)
       setPersona(id === 'All' ? null : (id as PersonaId))
+      if (id !== 'All') {
+        setShowEverything(false)
+        // Snap viewMode back to the persona's curated default unless the user is
+        // a researcher (no path) — they keep stack mode.
+        if (id === 'researcher') {
+          setViewMode('stack')
+        } else {
+          setViewMode('path')
+        }
+      }
     },
-    [setPersona]
+    [setPersona, setShowEverything]
   )
 
   const isModuleRelevant = useCallback(

--- a/src/components/PKILearning/Dashboard.tsx
+++ b/src/components/PKILearning/Dashboard.tsx
@@ -262,6 +262,11 @@ interface DesktopLearnFilterPopoverProps {
   sortBy: LearnSortMode
   personaFilterItems: { id: string; label: string }[]
   selectedPersonaFilter: string
+  /** P2-4: hide the NICE Proficiency filter block (used for curious until they opt in). */
+  hideNiceFilter?: boolean
+  /** P2-4: when true, render a "Show advanced filters" link inside the popover. */
+  showAdvancedFiltersToggle?: boolean
+  onAdvancedFiltersOpen?: () => void
   onTrackChange: (v: string) => void
   onDifficultyChange: (v: string) => void
   onStatusChange: (v: string) => void
@@ -282,6 +287,9 @@ const DesktopLearnFilterPopover: React.FC<DesktopLearnFilterPopoverProps> = ({
   sortBy,
   personaFilterItems,
   selectedPersonaFilter,
+  hideNiceFilter,
+  showAdvancedFiltersToggle,
+  onAdvancedFiltersOpen,
   onTrackChange,
   onDifficultyChange,
   onStatusChange,
@@ -392,41 +400,55 @@ const DesktopLearnFilterPopover: React.FC<DesktopLearnFilterPopoverProps> = ({
             />
           </div>
 
-          <div className="space-y-1.5 pt-3 border-t border-border/50">
-            <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground flex items-center gap-1">
-              <GraduationCap size={11} aria-hidden="true" />
-              NICE Proficiency
-            </span>
-            <div className="flex rounded-md overflow-hidden border border-border">
+          {showAdvancedFiltersToggle && onAdvancedFiltersOpen && (
+            <div className="pt-3 border-t border-border/50">
               <Button
-                variant="ghost"
-                onClick={() => onNiceTierChange('All')}
-                className={clsx(
-                  'flex-1 h-7 text-[11px] rounded-none border-r border-border',
-                  selectedNiceTier === 'All'
-                    ? 'bg-muted/60 text-foreground font-medium'
-                    : 'text-muted-foreground hover:text-foreground'
-                )}
+                variant="link"
+                size="sm"
+                onClick={onAdvancedFiltersOpen}
+                className="text-[11px] p-0 h-auto"
               >
-                All
+                Show advanced filters
               </Button>
-              {NICE_TIERS.map((tier) => (
+            </div>
+          )}
+          {!hideNiceFilter && (
+            <div className="space-y-1.5 pt-3 border-t border-border/50">
+              <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground flex items-center gap-1">
+                <GraduationCap size={11} aria-hidden="true" />
+                NICE Proficiency
+              </span>
+              <div className="flex rounded-md overflow-hidden border border-border">
                 <Button
-                  key={tier.id}
                   variant="ghost"
-                  onClick={() => onNiceTierChange(tier.id)}
+                  onClick={() => onNiceTierChange('All')}
                   className={clsx(
-                    'flex-1 h-7 text-[11px] rounded-none border-r border-border last:border-r-0',
-                    selectedNiceTier === tier.id
-                      ? 'bg-primary/10 text-primary font-medium'
+                    'flex-1 h-7 text-[11px] rounded-none border-r border-border',
+                    selectedNiceTier === 'All'
+                      ? 'bg-muted/60 text-foreground font-medium'
                       : 'text-muted-foreground hover:text-foreground'
                   )}
                 >
-                  {tier.label}
+                  All
                 </Button>
-              ))}
+                {NICE_TIERS.map((tier) => (
+                  <Button
+                    key={tier.id}
+                    variant="ghost"
+                    onClick={() => onNiceTierChange(tier.id)}
+                    className={clsx(
+                      'flex-1 h-7 text-[11px] rounded-none border-r border-border last:border-r-0',
+                      selectedNiceTier === tier.id
+                        ? 'bg-primary/10 text-primary font-medium'
+                        : 'text-muted-foreground hover:text-foreground'
+                    )}
+                  >
+                    {tier.label}
+                  </Button>
+                ))}
+              </div>
             </div>
-          </div>
+          )}
 
           <div className="space-y-1.5 pt-3 border-t border-border/50">
             <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
@@ -702,6 +724,10 @@ const ModuleTracksGrid = ({
   const [selectedNiceTier, setSelectedNiceTier] = useState<NiceProficiencyTier | 'All'>(
     niceTierOverridden ? storeNiceTier : 'All'
   )
+  // P2-4: NICE Proficiency is jargon for new learners. Hide it from curious by
+  // default; reveal under an "Advanced filters" toggle so power users can still
+  // engage it without surfacing the chrome on first paint.
+  const [advancedFiltersOpen, setAdvancedFiltersOpen] = useState(false)
 
   // Show Curious Explorer path in curious mode (persona or experience level); professionals see professional roles
   const isCuriousMode = selectedPersona === 'curious' || experienceLevel === 'curious'
@@ -1090,7 +1116,24 @@ const ModuleTracksGrid = ({
                     ))}
                   </div>
                 </div>
-                <div className="space-y-2 flex flex-col pt-4 border-t border-border/50">
+                {isCuriousMode && !advancedFiltersOpen && (
+                  <div className="pt-4 border-t border-border/50">
+                    <Button
+                      variant="link"
+                      size="sm"
+                      onClick={() => setAdvancedFiltersOpen(true)}
+                      className="text-xs"
+                    >
+                      Show advanced filters
+                    </Button>
+                  </div>
+                )}
+                <div
+                  className={clsx(
+                    'space-y-2 flex flex-col pt-4 border-t border-border/50',
+                    isCuriousMode && !advancedFiltersOpen && 'hidden'
+                  )}
+                >
                   <span className="text-sm font-semibold text-foreground flex items-center gap-1.5">
                     <GraduationCap size={14} aria-hidden="true" />
                     NICE Proficiency
@@ -1174,6 +1217,9 @@ const ModuleTracksGrid = ({
           sortBy={sortBy}
           personaFilterItems={personaFilterItems}
           selectedPersonaFilter={selectedPersonaFilter}
+          hideNiceFilter={isCuriousMode && !advancedFiltersOpen}
+          showAdvancedFiltersToggle={isCuriousMode && !advancedFiltersOpen}
+          onAdvancedFiltersOpen={() => setAdvancedFiltersOpen(true)}
           onTrackChange={setSelectedTrack}
           onDifficultyChange={setSelectedDifficulty}
           onStatusChange={setSelectedStatus}

--- a/src/components/PKILearning/LearnViewToggle.tsx
+++ b/src/components/PKILearning/LearnViewToggle.tsx
@@ -1,29 +1,33 @@
 // SPDX-License-Identifier: GPL-3.0-only
-import { Layers, LayoutGrid, Table } from 'lucide-react'
+import { Layers, LayoutGrid, Route, Table } from 'lucide-react'
 import clsx from 'clsx'
 import { Button } from '@/components/ui/button'
 
-export type LearnViewMode = 'stack' | 'cards' | 'table'
+export type LearnViewMode = 'path' | 'stack' | 'cards' | 'table'
 
 interface LearnViewToggleProps {
   mode: LearnViewMode
   onChange: (mode: LearnViewMode) => void
+  /** Hide the 'path' option when no persona is active (path mode requires a persona). */
+  pathAvailable?: boolean
 }
 
 const OPTIONS: { value: LearnViewMode; label: string; icon: typeof Layers }[] = [
+  { value: 'path', label: 'Path', icon: Route },
   { value: 'stack', label: 'Stack', icon: Layers },
   { value: 'cards', label: 'Cards', icon: LayoutGrid },
   { value: 'table', label: 'Table', icon: Table },
 ]
 
-export const LearnViewToggle = ({ mode, onChange }: LearnViewToggleProps) => {
+export const LearnViewToggle = ({ mode, onChange, pathAvailable = true }: LearnViewToggleProps) => {
+  const options = pathAvailable ? OPTIONS : OPTIONS.filter((o) => o.value !== 'path')
   return (
     <div
       className="flex items-center bg-muted/30 rounded-lg p-0.5 border border-border"
       role="radiogroup"
       aria-label="View mode"
     >
-      {OPTIONS.map(({ value, label, icon: Icon }) => (
+      {options.map(({ value, label, icon: Icon }) => (
         <Button
           variant="ghost"
           key={value}

--- a/src/components/PKILearning/PersonaPathPhase.tsx
+++ b/src/components/PKILearning/PersonaPathPhase.tsx
@@ -81,9 +81,15 @@ export const PersonaPathPhase = ({
             'shrink-0 rounded-full p-1',
             isComplete ? 'bg-status-success/15 text-status-success' : 'bg-muted text-muted-foreground'
           )}
-          aria-hidden="true"
         >
-          {isComplete ? <Check size={14} /> : <Circle size={14} />}
+          <span className="sr-only">
+            {isComplete ? 'Phase complete: ' : 'Phase in progress: '}
+          </span>
+          {isComplete ? (
+            <Check size={14} aria-hidden="true" />
+          ) : (
+            <Circle size={14} aria-hidden="true" />
+          )}
         </span>
         <div className="flex-1 min-w-0 flex items-center gap-2 flex-wrap">
           <span

--- a/src/components/PKILearning/PersonaPathPhase.tsx
+++ b/src/components/PKILearning/PersonaPathPhase.tsx
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0-only
 import { useEffect, useRef } from 'react'
-import { Check, ChevronRight, Circle } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
+import { Check, ChevronRight, Circle, FlaskConical } from 'lucide-react'
 import clsx from 'clsx'
 import { MODULE_CATALOG } from './moduleData'
 import { ModuleCard } from './ModuleCard'
+import { Button } from '../ui/button'
+import { getPlaygroundToolForModule } from './moduleEnrichment'
 import { logEvent, personaLabel } from '@/utils/analytics'
+import type { PersonaId } from '@/data/learningPersonas'
 
 interface PersonaPathPhaseProps {
   /** Phase title (checkpoint label, or "Wrap-up: Take the quiz" for the terminal phase). */
@@ -26,6 +30,8 @@ interface PersonaPathPhaseProps {
   /** Set of module IDs that should display a "Common Ground" overlay badge.
    *  Passed by PersonaPathView only when persona is executive/curious. */
   commonGroundModuleIds?: Set<string>
+  /** Active persona — drives P2-1 "Try in playground" affordance for ops. */
+  personaId?: PersonaId
   /** Callback when the user toggles the phase (writes to useLearnStore). */
   onToggle?: (expanded: boolean) => void
   /** Persisted expansion state. If undefined, defaultExpanded controls the initial state. */
@@ -42,9 +48,11 @@ export const PersonaPathPhase = ({
   isModuleRelevant,
   isModuleAboveLevel,
   commonGroundModuleIds,
+  personaId,
   onToggle,
   expandedOverride,
 }: PersonaPathPhaseProps) => {
+  const navigate = useNavigate()
   const ref = useRef<HTMLDetailsElement>(null)
   const isComplete = totalCount > 0 && completedCount === totalCount
 
@@ -109,6 +117,9 @@ export const PersonaPathPhase = ({
           const mod = MODULE_CATALOG[id]
           if (!mod) return null
           const isCommonGround = commonGroundModuleIds?.has(id) ?? false
+          // P2-1: surface a "Try in playground" affordance for ops persona when the
+          // module has a curated Playground tool counterpart.
+          const playgroundTool = personaId === 'ops' ? getPlaygroundToolForModule(id) : undefined
           return (
             <div key={id} className="relative">
               {isCommonGround && (
@@ -125,6 +136,21 @@ export const PersonaPathPhase = ({
                 isRelevant={isModuleRelevant(id)}
                 isAboveLevel={isModuleAboveLevel(id)}
               />
+              {playgroundTool && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    logEvent('Learning', 'Path Playground Link Click', `${id} → ${playgroundTool}`)
+                    navigate(`/playground/${playgroundTool}`)
+                  }}
+                  className="absolute bottom-2 right-2 z-10 text-[10px] gap-1 h-7 px-2"
+                >
+                  <FlaskConical size={11} aria-hidden="true" />
+                  Try in playground
+                </Button>
+              )}
             </div>
           )
         })}

--- a/src/components/PKILearning/PersonaPathPhase.tsx
+++ b/src/components/PKILearning/PersonaPathPhase.tsx
@@ -23,8 +23,9 @@ interface PersonaPathPhaseProps {
   isModuleRelevant: (moduleId: string) => boolean
   /** Persona-relevant signal (for ModuleCard dim/highlight). */
   isModuleAboveLevel: (moduleId: string) => boolean
-  /** Optional badge label rendered next to the title (e.g. "Common Ground" for executive/curious). */
-  badge?: string
+  /** Set of module IDs that should display a "Common Ground" overlay badge.
+   *  Passed by PersonaPathView only when persona is executive/curious. */
+  commonGroundModuleIds?: Set<string>
   /** Callback when the user toggles the phase (writes to useLearnStore). */
   onToggle?: (expanded: boolean) => void
   /** Persisted expansion state. If undefined, defaultExpanded controls the initial state. */
@@ -40,7 +41,7 @@ export const PersonaPathPhase = ({
   onSelectModule,
   isModuleRelevant,
   isModuleAboveLevel,
-  badge,
+  commonGroundModuleIds,
   onToggle,
   expandedOverride,
 }: PersonaPathPhaseProps) => {
@@ -98,11 +99,6 @@ export const PersonaPathPhase = ({
           >
             {title}
           </span>
-          {badge && (
-            <span className="text-[9px] font-mono uppercase tracking-wide px-1.5 py-0.5 rounded bg-primary/10 text-primary border border-primary/20">
-              {badge}
-            </span>
-          )}
         </div>
         <span className="text-xs text-muted-foreground shrink-0 tabular-nums">
           {completedCount} / {totalCount}
@@ -112,14 +108,24 @@ export const PersonaPathPhase = ({
         {moduleIds.map((id) => {
           const mod = MODULE_CATALOG[id]
           if (!mod) return null
+          const isCommonGround = commonGroundModuleIds?.has(id) ?? false
           return (
-            <ModuleCard
-              key={id}
-              module={mod}
-              onSelectModule={onSelectModule}
-              isRelevant={isModuleRelevant(id)}
-              isAboveLevel={isModuleAboveLevel(id)}
-            />
+            <div key={id} className="relative">
+              {isCommonGround && (
+                <span
+                  className="absolute top-2 right-2 z-10 text-[9px] font-mono uppercase tracking-wide px-1.5 py-0.5 rounded bg-primary/10 text-primary border border-primary/20 pointer-events-none"
+                  aria-label="Common Ground module"
+                >
+                  Common Ground
+                </span>
+              )}
+              <ModuleCard
+                module={mod}
+                onSelectModule={onSelectModule}
+                isRelevant={isModuleRelevant(id)}
+                isAboveLevel={isModuleAboveLevel(id)}
+              />
+            </div>
           )
         })}
       </div>

--- a/src/components/PKILearning/PersonaPathPhase.tsx
+++ b/src/components/PKILearning/PersonaPathPhase.tsx
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-3.0-only
+import { useEffect, useRef } from 'react'
+import { Check, ChevronRight, Circle } from 'lucide-react'
+import clsx from 'clsx'
+import { MODULE_CATALOG } from './moduleData'
+import { ModuleCard } from './ModuleCard'
+import { logEvent, personaLabel } from '@/utils/analytics'
+
+interface PersonaPathPhaseProps {
+  /** Phase title (checkpoint label, or "Wrap-up: Take the quiz" for the terminal phase). */
+  title: string
+  /** Module IDs contained in this phase. */
+  moduleIds: string[]
+  /** Whether the phase opens expanded on first render. */
+  defaultExpanded: boolean
+  /** Modules completed in this phase. */
+  completedCount: number
+  /** Total modules in this phase. */
+  totalCount: number
+  /** Click handler for module cards. */
+  onSelectModule: (moduleId: string) => void
+  /** Persona-relevant signal (for ModuleCard dim/highlight). */
+  isModuleRelevant: (moduleId: string) => boolean
+  /** Persona-relevant signal (for ModuleCard dim/highlight). */
+  isModuleAboveLevel: (moduleId: string) => boolean
+  /** Optional badge label rendered next to the title (e.g. "Common Ground" for executive/curious). */
+  badge?: string
+  /** Callback when the user toggles the phase (writes to useLearnStore). */
+  onToggle?: (expanded: boolean) => void
+  /** Persisted expansion state. If undefined, defaultExpanded controls the initial state. */
+  expandedOverride?: boolean
+}
+
+export const PersonaPathPhase = ({
+  title,
+  moduleIds,
+  defaultExpanded,
+  completedCount,
+  totalCount,
+  onSelectModule,
+  isModuleRelevant,
+  isModuleAboveLevel,
+  badge,
+  onToggle,
+  expandedOverride,
+}: PersonaPathPhaseProps) => {
+  const ref = useRef<HTMLDetailsElement>(null)
+  const isComplete = totalCount > 0 && completedCount === totalCount
+
+  // Sync open state with override when provided
+  useEffect(() => {
+    if (!ref.current) return
+    const desired = expandedOverride ?? defaultExpanded
+    if (ref.current.open !== desired) {
+      ref.current.open = desired
+    }
+  }, [expandedOverride, defaultExpanded])
+
+  const handleToggle = () => {
+    if (!ref.current) return
+    const next = ref.current.open
+    if (onToggle) onToggle(next)
+    logEvent('Learning', 'Path Phase Toggle', `${personaLabel(title)} · ${next ? 'open' : 'close'}`)
+  }
+
+  return (
+    <details
+      ref={ref}
+      open={expandedOverride ?? defaultExpanded}
+      onToggle={handleToggle}
+      className="glass-panel border-border/60 rounded-xl overflow-hidden group"
+    >
+      <summary className="flex items-center gap-3 px-4 py-3 cursor-pointer list-none hover:bg-muted/40 transition-colors">
+        <ChevronRight
+          size={16}
+          className="text-muted-foreground shrink-0 transition-transform group-open:rotate-90"
+          aria-hidden="true"
+        />
+        <span
+          className={clsx(
+            'shrink-0 rounded-full p-1',
+            isComplete ? 'bg-status-success/15 text-status-success' : 'bg-muted text-muted-foreground'
+          )}
+          aria-hidden="true"
+        >
+          {isComplete ? <Check size={14} /> : <Circle size={14} />}
+        </span>
+        <div className="flex-1 min-w-0 flex items-center gap-2 flex-wrap">
+          <span
+            className="text-sm font-semibold text-foreground line-clamp-1"
+            title={title}
+          >
+            {title}
+          </span>
+          {badge && (
+            <span className="text-[9px] font-mono uppercase tracking-wide px-1.5 py-0.5 rounded bg-primary/10 text-primary border border-primary/20">
+              {badge}
+            </span>
+          )}
+        </div>
+        <span className="text-xs text-muted-foreground shrink-0 tabular-nums">
+          {completedCount} / {totalCount}
+        </span>
+      </summary>
+      <div className="px-4 pb-4 pt-1 grid grid-cols-1 md:grid-cols-2 gap-4">
+        {moduleIds.map((id) => {
+          const mod = MODULE_CATALOG[id]
+          if (!mod) return null
+          return (
+            <ModuleCard
+              key={id}
+              module={mod}
+              onSelectModule={onSelectModule}
+              isRelevant={isModuleRelevant(id)}
+              isAboveLevel={isModuleAboveLevel(id)}
+            />
+          )
+        })}
+      </div>
+    </details>
+  )
+}

--- a/src/components/PKILearning/PersonaPathView.test.tsx
+++ b/src/components/PKILearning/PersonaPathView.test.tsx
@@ -46,12 +46,15 @@ describe('PersonaPathView — phase partitioning (P0-4)', () => {
 
   it('renders one phase per checkpoint plus a terminal wrap-up for curious', () => {
     renderView('curious')
-    // Plan: curious has 4 checkpoints → 5 phases (4 named + wrap-up)
-    expect(screen.getByText(/Understanding the Threat/i)).toBeInTheDocument()
-    expect(screen.getByText(/Why It Matters/i)).toBeInTheDocument()
-    expect(screen.getByText(/What the World Is Doing/i)).toBeInTheDocument()
-    expect(screen.getByText(/Practical Foundations/i)).toBeInTheDocument()
-    expect(screen.getByText(/Wrap-up: Take the quiz/i)).toBeInTheDocument()
+    // Plan: curious has 4 checkpoints → 5 phases (4 named + wrap-up).
+    // P2-2 also surfaces each phase title in the sticky breadcrumb for curious,
+    // so titles appear twice (breadcrumb item + <summary> in <details>) — use
+    // getAllByText and assert ≥1 occurrence.
+    expect(screen.getAllByText(/Understanding the Threat/i).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/Why It Matters/i).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/What the World Is Doing/i).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/Practical Foundations/i).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/Wrap-up: Take the quiz/i).length).toBeGreaterThan(0)
   })
 
   it('returns null when persona is unknown', () => {

--- a/src/components/PKILearning/PersonaPathView.test.tsx
+++ b/src/components/PKILearning/PersonaPathView.test.tsx
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: GPL-3.0-only
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import '@testing-library/jest-dom'
+import { PersonaPathView, computeNextIncompleteModuleId } from './PersonaPathView'
+import { useLearnStore } from '../../store/useLearnStore'
+import { useModuleStore } from '../../store/useModuleStore'
+import { PERSONAS } from '@/data/learningPersonas'
+
+const noop = () => {}
+const falseFn = () => false
+
+const renderView = (personaId: 'executive' | 'developer' | 'architect' | 'researcher' | 'ops' | 'curious', overrides?: { onShowEverything?: () => void }) =>
+  render(
+    <MemoryRouter>
+      <PersonaPathView
+        personaId={personaId}
+        onSelectModule={noop}
+        isModuleRelevant={falseFn}
+        isModuleAboveLevel={falseFn}
+        onShowEverything={overrides?.onShowEverything}
+      />
+    </MemoryRouter>
+  )
+
+const checkpointCount = (personaId: keyof typeof PERSONAS) =>
+  PERSONAS[personaId].pathItems.filter((p) => p.type === 'checkpoint').length
+
+describe('PersonaPathView — phase partitioning (P0-4)', () => {
+  beforeEach(() => {
+    useLearnStore.getState().reset()
+    useModuleStore.setState({ modules: {} })
+    localStorage.clear()
+  })
+
+  it('renders one phase per checkpoint plus a terminal wrap-up for executive', () => {
+    renderView('executive')
+    // Plan: executive has 5 checkpoints → 6 phases (5 named + wrap-up)
+    const expected = checkpointCount('executive') + 1
+    const summaries = screen.getAllByRole('group')
+    // <details> elements expose role=group — sanity check we have at least the expected count
+    expect(summaries.length).toBeGreaterThanOrEqual(expected)
+    expect(screen.getByText(/Wrap-up: Take the quiz/i)).toBeInTheDocument()
+  })
+
+  it('renders one phase per checkpoint plus a terminal wrap-up for curious', () => {
+    renderView('curious')
+    // Plan: curious has 4 checkpoints → 5 phases (4 named + wrap-up)
+    expect(screen.getByText(/Understanding the Threat/i)).toBeInTheDocument()
+    expect(screen.getByText(/Why It Matters/i)).toBeInTheDocument()
+    expect(screen.getByText(/What the World Is Doing/i)).toBeInTheDocument()
+    expect(screen.getByText(/Practical Foundations/i)).toBeInTheDocument()
+    expect(screen.getByText(/Wrap-up: Take the quiz/i)).toBeInTheDocument()
+  })
+
+  it('returns null when persona is unknown', () => {
+    // Cast through unknown to exercise the defensive branch in usePersonaPathItems
+    const { container } = render(
+      <MemoryRouter>
+        <PersonaPathView
+          // @ts-expect-error — testing the defensive branch
+          personaId={'nonsense'}
+          onSelectModule={noop}
+          isModuleRelevant={falseFn}
+          isModuleAboveLevel={falseFn}
+        />
+      </MemoryRouter>
+    )
+    expect(container.firstChild).toBeNull()
+  })
+})
+
+describe('PersonaPathView — curious "Show me everything" escape (P0-3)', () => {
+  beforeEach(() => {
+    useLearnStore.getState().reset()
+    useModuleStore.setState({ modules: {} })
+  })
+
+  it('renders the escape button only for curious + when onShowEverything is provided', () => {
+    const handler = vi.fn()
+    renderView('curious', { onShowEverything: handler })
+    expect(screen.getByRole('button', { name: /Show me everything/i })).toBeInTheDocument()
+  })
+
+  it('does NOT render the escape for non-curious personas', () => {
+    const handler = vi.fn()
+    renderView('executive', { onShowEverything: handler })
+    expect(screen.queryByRole('button', { name: /Show me everything/i })).not.toBeInTheDocument()
+  })
+
+  it('invokes onShowEverything when the escape is clicked', () => {
+    const handler = vi.fn()
+    renderView('curious', { onShowEverything: handler })
+    fireEvent.click(screen.getByRole('button', { name: /Show me everything/i }))
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('computeNextIncompleteModuleId — first-incomplete walk', () => {
+  it('returns the first non-completed module from pathItems', () => {
+    const pathItems = [
+      { type: 'module' as const, moduleId: 'a' },
+      { type: 'checkpoint' as const, moduleId: undefined },
+      { type: 'module' as const, moduleId: 'b' },
+      { type: 'module' as const, moduleId: 'c' },
+    ]
+    expect(computeNextIncompleteModuleId(pathItems, { a: 'completed', b: 'in-progress' })).toBe('b')
+  })
+
+  it('returns null when every module is completed', () => {
+    const pathItems = [
+      { type: 'module' as const, moduleId: 'a' },
+      { type: 'module' as const, moduleId: 'b' },
+    ]
+    expect(computeNextIncompleteModuleId(pathItems, { a: 'completed', b: 'completed' })).toBeNull()
+  })
+
+  it('treats absent modules as not-started (first one wins)', () => {
+    const pathItems = [{ type: 'module' as const, moduleId: 'x' }]
+    expect(computeNextIncompleteModuleId(pathItems, {})).toBe('x')
+  })
+
+  it('skips checkpoint nodes', () => {
+    const pathItems = [
+      { type: 'checkpoint' as const, moduleId: undefined },
+      { type: 'module' as const, moduleId: 'only' },
+    ]
+    expect(computeNextIncompleteModuleId(pathItems, {})).toBe('only')
+  })
+})

--- a/src/components/PKILearning/PersonaPathView.tsx
+++ b/src/components/PKILearning/PersonaPathView.tsx
@@ -94,8 +94,13 @@ export const PersonaPathView = ({
               const isComplete = idx < currentPhaseIdx
               return (
                 <li key={phase.id} className="flex items-center gap-1">
-                  {idx > 0 && <span className="text-muted-foreground/50">›</span>}
+                  {idx > 0 && (
+                    <span aria-hidden="true" className="text-muted-foreground/50">
+                      ›
+                    </span>
+                  )}
                   <span
+                    aria-current={isCurrent ? 'step' : undefined}
                     className={
                       isCurrent
                         ? 'font-semibold text-primary px-1.5 py-0.5 rounded bg-primary/10'
@@ -105,6 +110,7 @@ export const PersonaPathView = ({
                     }
                     title={phase.title}
                   >
+                    {isComplete && <span className="sr-only">Completed: </span>}
                     {phase.title}
                   </span>
                 </li>

--- a/src/components/PKILearning/PersonaPathView.tsx
+++ b/src/components/PKILearning/PersonaPathView.tsx
@@ -74,9 +74,45 @@ export const PersonaPathView = ({
   if (!summary) return null
 
   const showCommonGroundContext = personaId === 'executive' || personaId === 'curious'
+  // P2-2: sticky breadcrumb for ops + curious — their paths are the longest and
+  // benefit most from a global sense-of-progress overview.
+  const showBreadcrumb = personaId === 'ops' || personaId === 'curious'
+  const currentPhaseIdx = nextIncompleteId
+    ? summary.phases.findIndex((p) => p.moduleIds.includes(nextIncompleteId))
+    : summary.phases.length - 1
 
   return (
     <section aria-label="Your curated learning path" className="space-y-3">
+      {showBreadcrumb && summary.phases.length > 1 && (
+        <nav
+          aria-label="Path phases"
+          className="sticky top-0 z-10 -mx-2 px-2 py-2 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/70 border-b border-border/40 overflow-x-auto"
+        >
+          <ol className="flex items-center gap-1 text-xs whitespace-nowrap">
+            {summary.phases.map((phase, idx) => {
+              const isCurrent = idx === currentPhaseIdx
+              const isComplete = idx < currentPhaseIdx
+              return (
+                <li key={phase.id} className="flex items-center gap-1">
+                  {idx > 0 && <span className="text-muted-foreground/50">›</span>}
+                  <span
+                    className={
+                      isCurrent
+                        ? 'font-semibold text-primary px-1.5 py-0.5 rounded bg-primary/10'
+                        : isComplete
+                          ? 'text-status-success line-clamp-1'
+                          : 'text-muted-foreground line-clamp-1'
+                    }
+                    title={phase.title}
+                  >
+                    {phase.title}
+                  </span>
+                </li>
+              )
+            })}
+          </ol>
+        </nav>
+      )}
       {summary.phases.map((phase) => {
         const completedCount = phase.moduleIds.filter(
           (id) => modules[id]?.status === 'completed'

--- a/src/components/PKILearning/PersonaPathView.tsx
+++ b/src/components/PKILearning/PersonaPathView.tsx
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: GPL-3.0-only
+import { useMemo } from 'react'
+import { Sparkles } from 'lucide-react'
+import { Button } from '../ui/button'
+import { useModuleStore } from '../../store/useModuleStore'
+import { useLearnStore } from '../../store/useLearnStore'
+import type { PersonaId } from '@/data/learningPersonas'
+import { usePersonaPathItems } from './usePersonaPathItems'
+import { PersonaPathPhase } from './PersonaPathPhase'
+
+interface PersonaPathViewProps {
+  personaId: PersonaId
+  /** Click handler for module cards (delegates routing to caller). */
+  onSelectModule: (moduleId: string) => void
+  /** Persona-relevant dim/highlight signal forwarded to ModuleCard. */
+  isModuleRelevant: (moduleId: string) => boolean
+  /** Persona-relevant dim/highlight signal forwarded to ModuleCard. */
+  isModuleAboveLevel: (moduleId: string) => boolean
+  /** Triggered by the curious-only "Show me everything (advanced)" button. */
+  onShowEverything?: () => void
+}
+
+/** Module IDs counted as the "common ground" overlay between executive and curious paths. */
+const COMMON_GROUND_MODULE_IDS = new Set([
+  'pqc-101',
+  'compliance-strategy',
+  'vendor-risk',
+  'pqc-risk-management',
+  'migration-program',
+])
+
+/**
+ * Computes the next-incomplete module ID by walking pathItems in order. Returns the first
+ * module whose persisted status is not 'completed'. Exported so RecommendedPathBanner can
+ * share the same definition.
+ */
+export function computeNextIncompleteModuleId(
+  pathItems: readonly { type: 'module' | 'checkpoint'; moduleId?: string }[],
+  moduleStatusById: Record<string, string | undefined>
+): string | null {
+  for (const item of pathItems) {
+    if (item.type !== 'module') continue
+    const id = item.moduleId
+    if (!id) continue
+    if (moduleStatusById[id] !== 'completed') return id
+  }
+  return null
+}
+
+export const PersonaPathView = ({
+  personaId,
+  onSelectModule,
+  isModuleRelevant,
+  isModuleAboveLevel,
+  onShowEverything,
+}: PersonaPathViewProps) => {
+  const summary = usePersonaPathItems(personaId)
+  const modules = useModuleStore((s) => s.modules)
+  const phaseExpansion = useLearnStore((s) => s.phaseExpansion)
+  const setPhaseExpanded = useLearnStore((s) => s.setPhaseExpanded)
+
+  const nextIncompleteId = useMemo(() => {
+    if (!summary) return null
+    const statusMap: Record<string, string | undefined> = {}
+    for (const k of Object.keys(modules)) {
+      statusMap[k] = modules[k]?.status
+    }
+    return computeNextIncompleteModuleId(
+      summary.pathItems as { type: 'module' | 'checkpoint'; moduleId?: string }[],
+      statusMap
+    )
+  }, [summary, modules])
+
+  if (!summary) return null
+
+  const showCommonGroundContext = personaId === 'executive' || personaId === 'curious'
+
+  return (
+    <section aria-label="Your curated learning path" className="space-y-3">
+      {summary.phases.map((phase) => {
+        const completedCount = phase.moduleIds.filter(
+          (id) => modules[id]?.status === 'completed'
+        ).length
+        const totalCount = phase.moduleIds.length
+        const containsNext =
+          nextIncompleteId !== null && phase.moduleIds.includes(nextIncompleteId)
+        const defaultExpanded = containsNext
+        const key = `${personaId}:${phase.id}`
+        const expandedOverride =
+          // eslint-disable-next-line security/detect-object-injection
+          key in phaseExpansion ? phaseExpansion[key] : undefined
+        const containsCommonGround =
+          showCommonGroundContext && phase.moduleIds.some((id) => COMMON_GROUND_MODULE_IDS.has(id))
+        return (
+          <PersonaPathPhase
+            key={key}
+            title={phase.title}
+            moduleIds={phase.moduleIds}
+            defaultExpanded={defaultExpanded}
+            completedCount={completedCount}
+            totalCount={totalCount}
+            onSelectModule={onSelectModule}
+            isModuleRelevant={isModuleRelevant}
+            isModuleAboveLevel={isModuleAboveLevel}
+            badge={containsCommonGround ? 'Common Ground' : undefined}
+            expandedOverride={expandedOverride}
+            onToggle={(expanded) => setPhaseExpanded(key, expanded)}
+          />
+        )
+      })}
+
+      {personaId === 'curious' && onShowEverything && (
+        <div className="flex items-center justify-between gap-3 px-4 py-3 rounded-lg border border-dashed border-border/60 bg-muted/20">
+          <div className="flex items-center gap-2 min-w-0">
+            <Sparkles className="text-muted-foreground shrink-0" size={14} aria-hidden="true" />
+            <p className="text-xs text-muted-foreground line-clamp-2">
+              Want the full catalog? You can always come back to this curated path.
+            </p>
+          </div>
+          <Button variant="link" size="sm" className="shrink-0" onClick={onShowEverything}>
+            Show me everything (advanced)
+          </Button>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/PKILearning/PersonaPathView.tsx
+++ b/src/components/PKILearning/PersonaPathView.tsx
@@ -143,6 +143,7 @@ export const PersonaPathView = ({
             isModuleRelevant={isModuleRelevant}
             isModuleAboveLevel={isModuleAboveLevel}
             commonGroundModuleIds={showCommonGroundContext ? COMMON_GROUND_MODULE_IDS : undefined}
+            personaId={personaId}
             expandedOverride={expandedOverride}
             onToggle={(expanded) => setPhaseExpanded(key, expanded)}
           />

--- a/src/components/PKILearning/PersonaPathView.tsx
+++ b/src/components/PKILearning/PersonaPathView.tsx
@@ -21,7 +21,7 @@ interface PersonaPathViewProps {
 }
 
 /** Module IDs counted as the "common ground" overlay between executive and curious paths. */
-const COMMON_GROUND_MODULE_IDS = new Set([
+export const COMMON_GROUND_MODULE_IDS = new Set([
   'pqc-101',
   'compliance-strategy',
   'vendor-risk',
@@ -131,8 +131,6 @@ export const PersonaPathView = ({
         const expandedOverride =
           // eslint-disable-next-line security/detect-object-injection
           key in phaseExpansion ? phaseExpansion[key] : undefined
-        const containsCommonGround =
-          showCommonGroundContext && phase.moduleIds.some((id) => COMMON_GROUND_MODULE_IDS.has(id))
         return (
           <PersonaPathPhase
             key={key}
@@ -144,7 +142,7 @@ export const PersonaPathView = ({
             onSelectModule={onSelectModule}
             isModuleRelevant={isModuleRelevant}
             isModuleAboveLevel={isModuleAboveLevel}
-            badge={containsCommonGround ? 'Common Ground' : undefined}
+            commonGroundModuleIds={showCommonGroundContext ? COMMON_GROUND_MODULE_IDS : undefined}
             expandedOverride={expandedOverride}
             onToggle={(expanded) => setPhaseExpanded(key, expanded)}
           />

--- a/src/components/PKILearning/RecommendedPathBanner.test.tsx
+++ b/src/components/PKILearning/RecommendedPathBanner.test.tsx
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-3.0-only
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import '@testing-library/jest-dom'
+import { RecommendedPathBanner } from './RecommendedPathBanner'
+import { useModuleStore } from '../../store/useModuleStore'
+import { PERSONAS } from '@/data/learningPersonas'
+
+describe('RecommendedPathBanner', () => {
+  beforeEach(() => {
+    useModuleStore.setState({ modules: {} })
+  })
+
+  it('renders the persona label, module count, checkpoint count, and hours', () => {
+    const onResume = vi.fn()
+    render(
+      <MemoryRouter>
+        <RecommendedPathBanner personaId="executive" onResume={onResume} />
+      </MemoryRouter>
+    )
+
+    const persona = PERSONAS.executive
+    const moduleCount = persona.pathItems.filter((p) => p.type === 'module').length
+    const checkpointCount = persona.pathItems.filter((p) => p.type === 'checkpoint').length
+    const expectedHours = `~${Math.round(persona.estimatedMinutes / 60)}h`
+
+    expect(screen.getByText(persona.label)).toBeInTheDocument()
+    expect(
+      screen.getByText(new RegExp(`${moduleCount} modules · ${checkpointCount} checkpoints · ${expectedHours}`))
+    ).toBeInTheDocument()
+  })
+
+  it('shows the first incomplete module as the resume target', () => {
+    const persona = PERSONAS.executive
+    const firstModuleId = persona.pathItems.find((p) => p.type === 'module')?.moduleId as string
+    const onResume = vi.fn()
+
+    render(
+      <MemoryRouter>
+        <RecommendedPathBanner personaId="executive" onResume={onResume} />
+      </MemoryRouter>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /Resume/ }))
+    expect(onResume).toHaveBeenCalledWith(firstModuleId)
+  })
+
+  it('hides the Resume button when every module is completed', () => {
+    const persona = PERSONAS.executive
+    const allCompleted: Record<string, { status: 'completed'; completedSteps: string[]; learnSectionChecks: Record<string, boolean> }> = {}
+    for (const item of persona.pathItems) {
+      if (item.type === 'module') {
+        allCompleted[item.moduleId] = { status: 'completed', completedSteps: [], learnSectionChecks: {} }
+      }
+    }
+    useModuleStore.setState({ modules: allCompleted })
+
+    render(
+      <MemoryRouter>
+        <RecommendedPathBanner personaId="executive" onResume={() => {}} />
+      </MemoryRouter>
+    )
+
+    expect(screen.queryByRole('button', { name: /Resume/ })).not.toBeInTheDocument()
+  })
+})

--- a/src/components/PKILearning/RecommendedPathBanner.tsx
+++ b/src/components/PKILearning/RecommendedPathBanner.tsx
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-3.0-only
+import { useMemo } from 'react'
+import { motion } from 'framer-motion'
+import { ArrowRight, Route } from 'lucide-react'
+import { Button } from '../ui/button'
+import { useModuleStore } from '../../store/useModuleStore'
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion'
+import { PERSONAS, type PersonaId } from '@/data/learningPersonas'
+import { MODULE_CATALOG } from './moduleData'
+import { computeNextIncompleteModuleId } from './PersonaPathView'
+
+interface RecommendedPathBannerProps {
+  personaId: PersonaId
+  onResume: (moduleId: string) => void
+}
+
+/** Formats raw minutes into a compact human label (e.g. 725 → "~12h"). */
+function formatEstimatedHours(minutes: number): string {
+  if (minutes <= 0) return '~0h'
+  const hours = Math.round(minutes / 60)
+  return `~${hours}h`
+}
+
+export const RecommendedPathBanner = ({ personaId, onResume }: RecommendedPathBannerProps) => {
+  const persona = PERSONAS[personaId]
+  const modules = useModuleStore((s) => s.modules)
+  const reduced = usePrefersReducedMotion()
+
+  const moduleCount = useMemo(
+    () => persona.pathItems.filter((p) => p.type === 'module').length,
+    [persona.pathItems]
+  )
+  const checkpointCount = useMemo(
+    () => persona.pathItems.filter((p) => p.type === 'checkpoint').length,
+    [persona.pathItems]
+  )
+
+  const nextIncompleteId = useMemo(() => {
+    const statusMap: Record<string, string | undefined> = {}
+    for (const k of Object.keys(modules)) {
+      statusMap[k] = modules[k]?.status
+    }
+    return computeNextIncompleteModuleId(
+      persona.pathItems as { type: 'module' | 'checkpoint'; moduleId?: string }[],
+      statusMap
+    )
+  }, [persona.pathItems, modules])
+
+  // eslint-disable-next-line security/detect-object-injection
+  const nextModule = nextIncompleteId ? MODULE_CATALOG[nextIncompleteId] : null
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: reduced ? 0 : -8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: reduced ? 0 : 0.25 }}
+      className="glass-panel px-4 py-3 border-primary/30"
+    >
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div className="flex items-start gap-3 min-w-0 flex-1">
+          <Route className="text-primary shrink-0 mt-0.5" size={18} aria-hidden="true" />
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 flex-wrap mb-0.5">
+              <span className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+                Your path
+              </span>
+              <span className="text-sm font-semibold text-gradient">{persona.label}</span>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {moduleCount} modules · {checkpointCount} checkpoints ·{' '}
+              {formatEstimatedHours(persona.estimatedMinutes)}
+            </p>
+            {nextModule && (
+              <p className="text-xs text-foreground mt-1">
+                Next: <span className="font-medium">{nextModule.title}</span>
+              </p>
+            )}
+          </div>
+        </div>
+        {nextModule && (
+          <Button
+            variant="gradient"
+            size="sm"
+            onClick={() => onResume(nextModule.id)}
+            className="shrink-0"
+          >
+            Resume
+            <ArrowRight size={12} className="ml-1.5" aria-hidden="true" />
+          </Button>
+        )}
+      </div>
+    </motion.div>
+  )
+}

--- a/src/components/PKILearning/ResearcherTaxonomyFilter.test.tsx
+++ b/src/components/PKILearning/ResearcherTaxonomyFilter.test.tsx
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-3.0-only
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { ResearcherTaxonomyFilter } from './ResearcherTaxonomyFilter'
+
+describe('ResearcherTaxonomyFilter', () => {
+  it('renders Algorithm and Standard top-level buttons collapsed by default', () => {
+    render(
+      <ResearcherTaxonomyFilter
+        selection={{ algorithm: null, standard: null }}
+        onChange={() => {}}
+      />
+    )
+    expect(screen.getByRole('button', { name: /Algorithm/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Standard/ })).toBeInTheDocument()
+    // No listbox open until a category is clicked
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('opens the algorithm listbox when the Algorithm button is clicked', () => {
+    render(
+      <ResearcherTaxonomyFilter
+        selection={{ algorithm: null, standard: null }}
+        onChange={() => {}}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Algorithm/ }))
+    expect(screen.getByRole('listbox', { name: /Algorithms/i })).toBeInTheDocument()
+    // ML-KEM chip is rendered as an option
+    expect(screen.getByRole('option', { name: /ML-KEM/ })).toBeInTheDocument()
+  })
+
+  it('publishes a selection upward when an algorithm option is clicked', () => {
+    const onChange = vi.fn()
+    render(
+      <ResearcherTaxonomyFilter
+        selection={{ algorithm: null, standard: null }}
+        onChange={onChange}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Algorithm/ }))
+    fireEvent.click(screen.getByRole('option', { name: /ML-DSA/ }))
+    expect(onChange).toHaveBeenCalledWith({ algorithm: 'ML-DSA', standard: null })
+  })
+
+  it('selecting a standard clears any algorithm selection (mutually exclusive)', () => {
+    const onChange = vi.fn()
+    render(
+      <ResearcherTaxonomyFilter
+        selection={{ algorithm: 'ML-KEM', standard: null }}
+        onChange={onChange}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Standard/ }))
+    fireEvent.click(screen.getByRole('option', { name: /FIPS 203/ }))
+    expect(onChange).toHaveBeenCalledWith({ algorithm: null, standard: 'FIPS 203' })
+  })
+
+  it('Clear button resets both selections', () => {
+    const onChange = vi.fn()
+    render(
+      <ResearcherTaxonomyFilter
+        selection={{ algorithm: 'ML-KEM', standard: null }}
+        onChange={onChange}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Clear/ }))
+    expect(onChange).toHaveBeenCalledWith({ algorithm: null, standard: null })
+  })
+})

--- a/src/components/PKILearning/ResearcherTaxonomyFilter.tsx
+++ b/src/components/PKILearning/ResearcherTaxonomyFilter.tsx
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// P2-3: secondary axis for researcher mode — browse modules by the PQC
+// algorithm they cover or the standard they reference. Renders as two chip
+// rows above the stack. Selecting a chip filters via the existing
+// filteredModuleIds Set in Dashboard.tsx, so this component is purely a
+// presentational chip group that publishes a selection up.
+
+import { useState } from 'react'
+import clsx from 'clsx'
+import { ALGORITHM_TAXONOMY, STANDARD_TAXONOMY } from './moduleEnrichment'
+import type { AlgorithmTaxon, StandardTaxon } from './moduleEnrichment'
+import { Button } from '../ui/button'
+
+export interface TaxonomySelection {
+  algorithm: AlgorithmTaxon | null
+  standard: StandardTaxon | null
+}
+
+interface ResearcherTaxonomyFilterProps {
+  selection: TaxonomySelection
+  onChange: (next: TaxonomySelection) => void
+}
+
+export const ResearcherTaxonomyFilter = ({
+  selection,
+  onChange,
+}: ResearcherTaxonomyFilterProps) => {
+  const [open, setOpen] = useState<'algorithm' | 'standard' | null>(null)
+
+  const setAlgorithm = (algorithm: AlgorithmTaxon | null) => {
+    onChange({ algorithm, standard: null })
+  }
+  const setStandard = (standard: StandardTaxon | null) => {
+    onChange({ algorithm: null, standard })
+  }
+
+  const activeLabel = selection.algorithm ?? selection.standard ?? null
+
+  return (
+    <section
+      aria-label="Researcher: browse modules by algorithm or standard"
+      className="space-y-2"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          Browse by
+        </span>
+        <Button
+          variant={open === 'algorithm' ? 'gradient' : 'outline'}
+          size="sm"
+          onClick={() => setOpen(open === 'algorithm' ? null : 'algorithm')}
+          className="text-xs h-7"
+          aria-expanded={open === 'algorithm'}
+        >
+          Algorithm
+          {selection.algorithm && (
+            <span className="ml-1.5 text-[10px] opacity-80">· {selection.algorithm}</span>
+          )}
+        </Button>
+        <Button
+          variant={open === 'standard' ? 'gradient' : 'outline'}
+          size="sm"
+          onClick={() => setOpen(open === 'standard' ? null : 'standard')}
+          className="text-xs h-7"
+          aria-expanded={open === 'standard'}
+        >
+          Standard
+          {selection.standard && (
+            <span className="ml-1.5 text-[10px] opacity-80">· {selection.standard}</span>
+          )}
+        </Button>
+        {activeLabel && (
+          <Button
+            variant="link"
+            size="sm"
+            onClick={() => {
+              setAlgorithm(null)
+              setStandard(null)
+              setOpen(null)
+            }}
+            className="text-xs"
+          >
+            Clear
+          </Button>
+        )}
+      </div>
+
+      {open === 'algorithm' && (
+        <div
+          role="listbox"
+          aria-label="Algorithms"
+          className="flex flex-wrap gap-1.5 p-2 rounded-lg border border-border bg-muted/30"
+        >
+          {ALGORITHM_TAXONOMY.map((alg) => {
+            const isSelected = selection.algorithm === alg
+            return (
+              <Button
+                key={alg}
+                variant="ghost"
+                size="sm"
+                role="option"
+                aria-selected={isSelected}
+                onClick={() => setAlgorithm(isSelected ? null : alg)}
+                className={clsx(
+                  'text-[11px] h-6 px-2 rounded-full border',
+                  isSelected
+                    ? 'border-primary bg-primary/10 text-primary'
+                    : 'border-border text-muted-foreground hover:text-foreground'
+                )}
+              >
+                {alg}
+              </Button>
+            )
+          })}
+        </div>
+      )}
+
+      {open === 'standard' && (
+        <div
+          role="listbox"
+          aria-label="Standards"
+          className="flex flex-wrap gap-1.5 p-2 rounded-lg border border-border bg-muted/30"
+        >
+          {STANDARD_TAXONOMY.map((std) => {
+            const isSelected = selection.standard === std
+            return (
+              <Button
+                key={std}
+                variant="ghost"
+                size="sm"
+                role="option"
+                aria-selected={isSelected}
+                onClick={() => setStandard(isSelected ? null : std)}
+                className={clsx(
+                  'text-[11px] h-6 px-2 rounded-full border',
+                  isSelected
+                    ? 'border-primary bg-primary/10 text-primary'
+                    : 'border-border text-muted-foreground hover:text-foreground'
+                )}
+              >
+                {std}
+              </Button>
+            )
+          })}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/PKILearning/moduleEnrichment.test.ts
+++ b/src/components/PKILearning/moduleEnrichment.test.ts
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-3.0-only
+import { describe, it, expect } from 'vitest'
+import {
+  MODULE_PLAYGROUND_TOOL,
+  MODULE_TAXONOMY,
+  getPlaygroundToolForModule,
+  shouldShowPlaygroundLink,
+  getModuleAlgorithms,
+  getModuleStandards,
+  modulesByAlgorithm,
+  modulesByStandard,
+} from './moduleEnrichment'
+
+describe('moduleEnrichment — playground mapping (P2-1)', () => {
+  it('returns the curated tool id for known modules', () => {
+    expect(getPlaygroundToolForModule('tls-basics')).toBe('tls-simulator')
+    expect(getPlaygroundToolForModule('email-signing')).toBe('email-signing')
+    expect(getPlaygroundToolForModule('pki-workshop')).toBe('pki-workshop')
+  })
+
+  it('returns undefined for modules without a curated mapping', () => {
+    expect(getPlaygroundToolForModule('pqc-101')).toBeUndefined()
+    expect(getPlaygroundToolForModule('nonexistent-module')).toBeUndefined()
+  })
+
+  it('shouldShowPlaygroundLink only fires for ops persona with a mapped module', () => {
+    expect(shouldShowPlaygroundLink('ops', 'tls-basics')).toBe(true)
+    expect(shouldShowPlaygroundLink('ops', 'pqc-101')).toBe(false) // no mapping
+    expect(shouldShowPlaygroundLink('developer', 'tls-basics')).toBe(false) // wrong persona
+    expect(shouldShowPlaygroundLink(null, 'tls-basics')).toBe(false)
+  })
+
+  it('every mapped Playground tool id is non-empty and lowercase-hyphen', () => {
+    for (const [moduleId, toolId] of Object.entries(MODULE_PLAYGROUND_TOOL)) {
+      expect(toolId.length).toBeGreaterThan(0)
+      expect(toolId).toMatch(/^[a-z0-9-]+$/)
+      expect(moduleId.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('moduleEnrichment — researcher taxonomy (P2-3)', () => {
+  it('returns the curated algorithm list for tagged modules', () => {
+    expect(getModuleAlgorithms('pqc-101')).toEqual(['ML-KEM', 'ML-DSA', 'SLH-DSA'])
+    expect(getModuleAlgorithms('hybrid-crypto')).toContain('ML-KEM')
+    expect(getModuleAlgorithms('hybrid-crypto')).toContain('X25519')
+  })
+
+  it('returns an empty list for untagged modules', () => {
+    expect(getModuleAlgorithms('untagged-module')).toEqual([])
+    expect(getModuleStandards('untagged-module')).toEqual([])
+  })
+
+  it('modulesByAlgorithm finds every tagged module', () => {
+    const ml_kem = modulesByAlgorithm('ML-KEM')
+    expect(ml_kem).toContain('pqc-101')
+    expect(ml_kem).toContain('tls-basics')
+    expect(ml_kem).toContain('hybrid-crypto')
+    // sanity — not all modules
+    expect(ml_kem.length).toBeLessThan(Object.keys(MODULE_TAXONOMY).length + 1)
+  })
+
+  it('modulesByStandard finds every tagged module', () => {
+    const fips_205 = modulesByStandard('FIPS 205')
+    expect(fips_205).toContain('slh-dsa')
+
+    const jose = modulesByStandard('JOSE')
+    expect(jose).toContain('email-signing')
+    expect(jose).toContain('api-security-jwt')
+  })
+
+  it('every taxonomy entry references real algorithm / standard tokens', () => {
+    const ALGS = new Set([
+      'ML-KEM',
+      'ML-DSA',
+      'SLH-DSA',
+      'Falcon',
+      'LMS/XMSS',
+      'HQC',
+      'RSA',
+      'ECDSA',
+      'ECDH',
+      'X25519',
+    ])
+    const STDS = new Set([
+      'FIPS 203',
+      'FIPS 204',
+      'FIPS 205',
+      'NIST SP 800-208',
+      'RFC 9421',
+      'RFC 9180',
+      'RFC 9442',
+      'RFC 9794',
+      'X.509',
+      'PKCS#11',
+      'JOSE',
+    ])
+    for (const entry of Object.values(MODULE_TAXONOMY)) {
+      for (const alg of entry.algorithms ?? []) {
+        expect(ALGS.has(alg)).toBe(true)
+      }
+      for (const std of entry.standards ?? []) {
+        expect(STDS.has(std)).toBe(true)
+      }
+    }
+  })
+})

--- a/src/components/PKILearning/moduleEnrichment.ts
+++ b/src/components/PKILearning/moduleEnrichment.ts
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// Optional per-module enrichments used by the persona-path view to surface:
+//   - P2-1: "Try in /playground" affordance for ops persona, when a module
+//           has an obvious hands-on counterpart in the Playground workshop
+//           registry (src/components/Playground/workshopRegistry.tsx).
+//   - P2-3: "Browse by algorithm / standard" secondary axis for researcher,
+//           derived from a curated taxonomy that maps each Learn module to
+//           the PQC algorithms it covers and the standards / RFCs / drafts
+//           it references.
+//
+// Both maps are intentionally PARTIAL — they only cover modules where the
+// mapping is unambiguous from the module's curriculum. Unknown modules return
+// undefined / [] and the UI degrades to the same affordances as before.
+
+import type { PersonaId } from '@/data/learningPersonas'
+
+/**
+ * Learn-module → Playground-tool mapping. The string value is a Playground
+ * tool `id` (validated against workshopRegistry at runtime is overkill —
+ * mismatches degrade to a dead link, not a crash).
+ */
+export const MODULE_PLAYGROUND_TOOL: Readonly<Record<string, string>> = {
+  // Protocol simulators
+  'tls-basics': 'tls-simulator',
+  'vpn-ssh-pqc': 'vpn-sim',
+
+  // PKI workbench
+  'pki-workshop': 'pki-workshop',
+  'pki-enrollment-protocols': 'pki-enrollment',
+  'hybrid-crypto': 'hybrid-certs',
+  'merkle-tree-certs': 'merkle-proof',
+
+  // Identity & messaging
+  'email-signing': 'email-signing',
+  'mls-group-messaging': 'mls-group-messaging',
+  'digital-id': 'digital-id',
+  'api-security-jwt': 'api-security-jwt',
+
+  // Code/firmware signing
+  'code-signing': 'firmware-signing',
+  'stateful-signatures': 'lms-hss',
+  'slh-dsa': 'slh-dsa',
+
+  // Randomness
+  'entropy-randomness': 'entropy-test',
+
+  // Industry workshops
+  '5g-security': 'suci-flow',
+  'digital-assets': 'bitcoin-flow',
+
+  // KEM playgrounds
+  'kms-pqc': 'envelope-encrypt',
+}
+
+/** Returns the matching Playground tool id, or undefined when no curated mapping exists. */
+export function getPlaygroundToolForModule(moduleId: string): string | undefined {
+  // eslint-disable-next-line security/detect-object-injection
+  return MODULE_PLAYGROUND_TOOL[moduleId]
+}
+
+/**
+ * Returns true when the active persona should see the "Try in /playground"
+ * affordance for this module. Plan says ops persona only.
+ */
+export function shouldShowPlaygroundLink(
+  personaId: PersonaId | null | undefined,
+  moduleId: string
+): boolean {
+  if (personaId !== 'ops') return false
+  return getPlaygroundToolForModule(moduleId) !== undefined
+}
+
+// ---------------------------------------------------------------------------
+// P2-3: researcher taxonomy
+// ---------------------------------------------------------------------------
+
+/**
+ * Algorithm tokens used by the researcher 2nd-axis filter. Kept short and
+ * standardised so the chip row stays compact. ML-KEM / ML-DSA / SLH-DSA are
+ * the three FIPS-finalised PQC primitives; the rest are protocol-relevant
+ * classical algorithms or NIST 4th-round / draft candidates.
+ */
+export const ALGORITHM_TAXONOMY = [
+  'ML-KEM',
+  'ML-DSA',
+  'SLH-DSA',
+  'Falcon',
+  'LMS/XMSS',
+  'HQC',
+  'RSA',
+  'ECDSA',
+  'ECDH',
+  'X25519',
+] as const
+
+export type AlgorithmTaxon = (typeof ALGORITHM_TAXONOMY)[number]
+
+/**
+ * Standard / specification tokens. Short labels keep the chip row readable.
+ * The values mirror the canonical doc-ID shapes used elsewhere
+ * (`FIPS 203`, `RFC 9421`, `IETF draft-ietf-...`).
+ */
+export const STANDARD_TAXONOMY = [
+  'FIPS 203',
+  'FIPS 204',
+  'FIPS 205',
+  'NIST SP 800-208',
+  'RFC 9421',
+  'RFC 9180',
+  'RFC 9442',
+  'RFC 9794',
+  'X.509',
+  'PKCS#11',
+  'JOSE',
+] as const
+
+export type StandardTaxon = (typeof STANDARD_TAXONOMY)[number]
+
+interface ModuleTaxonomyEntry {
+  algorithms?: AlgorithmTaxon[]
+  standards?: StandardTaxon[]
+}
+
+/**
+ * Curated taxonomy for the researcher 2nd-axis filter. PARTIAL on purpose:
+ * only modules with unambiguous algorithm / standard coverage are tagged.
+ */
+export const MODULE_TAXONOMY: Readonly<Record<string, ModuleTaxonomyEntry>> = {
+  'pqc-101': { algorithms: ['ML-KEM', 'ML-DSA', 'SLH-DSA'] },
+  'pqc-candidates': { algorithms: ['ML-KEM', 'ML-DSA', 'SLH-DSA', 'Falcon', 'HQC'] },
+  'hybrid-crypto': { algorithms: ['ML-KEM', 'X25519', 'ECDH'], standards: ['RFC 9180'] },
+  'tls-basics': {
+    algorithms: ['ML-KEM', 'X25519', 'ECDSA', 'ML-DSA'],
+    standards: ['RFC 9180', 'X.509'],
+  },
+  'vpn-ssh-pqc': { algorithms: ['ML-KEM', 'ECDH'], standards: ['RFC 9442'] },
+  'pki-workshop': {
+    algorithms: ['ML-DSA', 'ECDSA', 'RSA'],
+    standards: ['X.509', 'FIPS 204'],
+  },
+  'hybrid-certs': {
+    algorithms: ['ML-DSA', 'ECDSA'],
+    standards: ['X.509', 'RFC 9794'],
+  },
+  'email-signing': { algorithms: ['ML-DSA'], standards: ['JOSE', 'X.509'] },
+  'api-security-jwt': { algorithms: ['ML-DSA', 'SLH-DSA'], standards: ['JOSE', 'RFC 9421'] },
+  'slh-dsa': { algorithms: ['SLH-DSA'], standards: ['FIPS 205'] },
+  'stateful-signatures': { algorithms: ['LMS/XMSS'], standards: ['NIST SP 800-208'] },
+  'code-signing': { algorithms: ['ML-DSA', 'LMS/XMSS'], standards: ['FIPS 204', 'NIST SP 800-208'] },
+  'hsm-pqc': { algorithms: ['ML-KEM', 'ML-DSA'], standards: ['PKCS#11'] },
+  'kms-pqc': { algorithms: ['ML-KEM'], standards: ['FIPS 203'] },
+  'merkle-tree-certs': { algorithms: ['LMS/XMSS'], standards: ['NIST SP 800-208'] },
+  '5g-security': { algorithms: ['ML-KEM', 'ML-DSA'], standards: ['X.509'] },
+  'digital-id': { algorithms: ['ML-DSA'], standards: ['X.509'] },
+  'mls-group-messaging': { algorithms: ['ML-KEM', 'ML-DSA'], standards: ['JOSE'] },
+}
+
+export function getModuleAlgorithms(moduleId: string): readonly AlgorithmTaxon[] {
+  // eslint-disable-next-line security/detect-object-injection
+  return MODULE_TAXONOMY[moduleId]?.algorithms ?? []
+}
+
+export function getModuleStandards(moduleId: string): readonly StandardTaxon[] {
+  // eslint-disable-next-line security/detect-object-injection
+  return MODULE_TAXONOMY[moduleId]?.standards ?? []
+}
+
+/**
+ * Returns the subset of module IDs whose taxonomy includes the given algorithm.
+ * O(taxonomy-size) — kept linear since taxonomy is < 50 entries.
+ */
+export function modulesByAlgorithm(algorithm: AlgorithmTaxon): string[] {
+  const ids: string[] = []
+  for (const [moduleId, entry] of Object.entries(MODULE_TAXONOMY)) {
+    if (entry.algorithms?.includes(algorithm)) ids.push(moduleId)
+  }
+  return ids
+}
+
+export function modulesByStandard(standard: StandardTaxon): string[] {
+  const ids: string[] = []
+  for (const [moduleId, entry] of Object.entries(MODULE_TAXONOMY)) {
+    if (entry.standards?.includes(standard)) ids.push(moduleId)
+  }
+  return ids
+}

--- a/src/components/PKILearning/usePersonaPathItems.ts
+++ b/src/components/PKILearning/usePersonaPathItems.ts
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-3.0-only
+import { useMemo } from 'react'
+import { PERSONAS, type PersonaId, type PathItem } from '@/data/learningPersonas'
+import { MODULE_CATALOG, MODULE_TO_TRACK } from './moduleData'
+import type { ModuleTableItem } from './ModuleTable'
+
+export interface PersonaPathPhase {
+  /** Phase key: the closing checkpoint id or 'wrap-up' for the terminal quiz phase. */
+  id: string
+  /** Phase title from the checkpoint label, or "Wrap-up" for the terminal phase. */
+  title: string
+  /** Module IDs contained in this phase, in order. */
+  moduleIds: string[]
+  /** Quiz category list from the closing checkpoint (empty for wrap-up). */
+  categories: string[]
+}
+
+export interface PersonaPathSummary {
+  personaId: PersonaId
+  pathItems: readonly PathItem[]
+  moduleCount: number
+  checkpointCount: number
+  estimatedMinutes: number
+  /** Phases partitioned on checkpoint nodes, plus a terminal "Wrap-up" phase for the quiz. */
+  phases: PersonaPathPhase[]
+  /** Flat module/checkpoint list shaped for ModuleTable (re-used by cards/table modes). */
+  flatItems: ModuleTableItem[]
+}
+
+/**
+ * Shared persona-path computation used by both PersonaPathView and Dashboard.flatItems.
+ * Walks PERSONAS[personaId].pathItems, partitions on checkpoint nodes, and synthesizes a
+ * terminal "Wrap-up" phase for the trailing `quiz` module so the renderer can treat the
+ * quiz uniformly as part of a phase rather than as a special-case sibling.
+ *
+ * Returns null when personaId is unknown (defensive — every PersonaId in the union is
+ * present in PERSONAS but the input type is widened to string at deep-link boundaries).
+ */
+export function usePersonaPathItems(personaId: string | null | undefined): PersonaPathSummary | null {
+  return useMemo(() => {
+    if (!personaId) return null
+    const persona = PERSONAS[personaId as PersonaId]
+    if (!persona) return null
+
+    const phases: PersonaPathPhase[] = []
+    let buffer: string[] = []
+    let trailingQuizId: string | null = null
+
+    for (let i = 0; i < persona.pathItems.length; i++) {
+      const item = persona.pathItems[i]
+      if (item.type === 'module') {
+        // Hold the terminal quiz module out for the wrap-up phase
+        const isLast = i === persona.pathItems.length - 1
+        if (isLast && item.moduleId === 'quiz') {
+          trailingQuizId = item.moduleId
+        } else {
+          buffer.push(item.moduleId)
+        }
+      } else {
+        // Checkpoint closes the current phase
+        phases.push({
+          id: item.id,
+          title: item.label,
+          moduleIds: buffer,
+          categories: item.categories as string[],
+        })
+        buffer = []
+      }
+    }
+
+    // Any modules left without a closing checkpoint form an implicit final phase
+    if (buffer.length > 0) {
+      phases.push({
+        id: 'implicit-final',
+        title: 'Final modules',
+        moduleIds: buffer,
+        categories: [],
+      })
+    }
+
+    // Terminal wrap-up containing the quiz
+    if (trailingQuizId) {
+      phases.push({
+        id: 'wrap-up',
+        title: 'Wrap-up: Take the quiz',
+        moduleIds: [trailingQuizId],
+        categories: [],
+      })
+    }
+
+    const moduleCount = persona.pathItems.filter((p) => p.type === 'module').length
+    const checkpointCount = persona.pathItems.filter((p) => p.type === 'checkpoint').length
+
+    const flatItems: ModuleTableItem[] = persona.pathItems.map((item) => {
+      if (item.type === 'module') {
+        const mod = MODULE_CATALOG[item.moduleId]
+        return {
+          kind: 'module' as const,
+          module: mod,
+          track: MODULE_TO_TRACK[item.moduleId] ?? '',
+        }
+      }
+      return {
+        kind: 'checkpoint' as const,
+        id: item.id,
+        label: item.label,
+        categoryCount: item.categories.length,
+        categories: item.categories as string[],
+      }
+    })
+
+    return {
+      personaId: persona.id,
+      pathItems: persona.pathItems,
+      moduleCount,
+      checkpointCount,
+      estimatedMinutes: persona.estimatedMinutes,
+      phases,
+      flatItems,
+    }
+  }, [personaId])
+}

--- a/src/store/useLearnStore.test.ts
+++ b/src/store/useLearnStore.test.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-3.0-only
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useLearnStore } from './useLearnStore'
+
+describe('useLearnStore', () => {
+  beforeEach(() => {
+    useLearnStore.getState().reset()
+    localStorage.clear()
+  })
+
+  it('starts with safe defaults', () => {
+    const state = useLearnStore.getState()
+    expect(state.showEverything).toBe(false)
+    expect(state.phaseExpansion).toEqual({})
+    expect(state.researcherSortOverride).toBeNull()
+  })
+
+  it('setShowEverything flips the curious escape', () => {
+    useLearnStore.getState().setShowEverything(true)
+    expect(useLearnStore.getState().showEverything).toBe(true)
+    useLearnStore.getState().setShowEverything(false)
+    expect(useLearnStore.getState().showEverything).toBe(false)
+  })
+
+  it('setPhaseExpanded writes per-key without disturbing siblings', () => {
+    useLearnStore.getState().setPhaseExpanded('curious:cp-1', true)
+    useLearnStore.getState().setPhaseExpanded('curious:cp-2', false)
+    expect(useLearnStore.getState().phaseExpansion).toEqual({
+      'curious:cp-1': true,
+      'curious:cp-2': false,
+    })
+  })
+
+  it('reset returns to defaults', () => {
+    useLearnStore.getState().setShowEverything(true)
+    useLearnStore.getState().setPhaseExpanded('x', true)
+    useLearnStore.getState().setResearcherSortOverride('recently')
+    useLearnStore.getState().reset()
+    const s = useLearnStore.getState()
+    expect(s.showEverything).toBe(false)
+    expect(s.phaseExpansion).toEqual({})
+    expect(s.researcherSortOverride).toBeNull()
+  })
+
+  it('persists to localStorage under pqc-learn-storage', () => {
+    useLearnStore.getState().setShowEverything(true)
+    const raw = localStorage.getItem('pqc-learn-storage')
+    expect(raw).not.toBeNull()
+    const parsed = JSON.parse(raw as string)
+    expect(parsed.version).toBe(1)
+    expect(parsed.state.showEverything).toBe(true)
+  })
+})

--- a/src/store/useLearnStore.ts
+++ b/src/store/useLearnStore.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0-only
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+
+export interface LearnState {
+  /** Curious-only escape from the curated path back into the full 55-module catalog. */
+  showEverything: boolean
+  setShowEverything: (value: boolean) => void
+  /** Per-persona phase expansion override, keyed by `${personaId}:${checkpointId|'wrap-up'}`. */
+  phaseExpansion: Record<string, boolean>
+  setPhaseExpanded: (key: string, expanded: boolean) => void
+  /** Researcher-only sort override so changing personas doesn't clobber their selection. */
+  researcherSortOverride: string | null
+  setResearcherSortOverride: (value: string | null) => void
+  reset: () => void
+}
+
+const defaults: Pick<
+  LearnState,
+  'showEverything' | 'phaseExpansion' | 'researcherSortOverride'
+> = {
+  showEverything: false,
+  phaseExpansion: {},
+  researcherSortOverride: null,
+}
+
+export const useLearnStore = create<LearnState>()(
+  persist(
+    (set) => ({
+      ...defaults,
+      setShowEverything: (value) => set({ showEverything: value }),
+      setPhaseExpanded: (key, expanded) =>
+        set((state) => ({ phaseExpansion: { ...state.phaseExpansion, [key]: expanded } })),
+      setResearcherSortOverride: (value) => set({ researcherSortOverride: value }),
+      reset: () => set({ ...defaults }),
+    }),
+    {
+      name: 'pqc-learn-storage',
+      version: 1,
+      storage: createJSONStorage(() => localStorage),
+      migrate: (persistedState: unknown, version: number) => {
+        const state =
+          typeof persistedState === 'object' && persistedState !== null
+            ? (persistedState as Record<string, unknown>)
+            : {}
+
+        if (version < 1) {
+          state.showEverything = typeof state.showEverything === 'boolean' ? state.showEverything : false
+          state.phaseExpansion =
+            typeof state.phaseExpansion === 'object' && state.phaseExpansion !== null
+              ? state.phaseExpansion
+              : {}
+          state.researcherSortOverride =
+            typeof state.researcherSortOverride === 'string' ? state.researcherSortOverride : null
+        }
+
+        return state as unknown as LearnState
+      },
+      onRehydrateStorage: () => (_state, error) => {
+        if (error) {
+          console.error('Learn store rehydration failed:', error)
+        }
+      },
+    }
+  )
+)


### PR DESCRIPTION
## Summary

Implements the [Learn implementation plan](https://github.com/pqctoday-org/pqctoday-priv/blob/main/docs/platform/ux/page-audits/2026-05-22-persona-overwhelm/plans/learn.md) end-to-end. The headline fix: every persona now lands on its own curated, phased learning path above the fold; the 55-module catalog stays one click away via `<details>`.

Closes the persona-overwhelm audit's #1 finding for `/learn` — the curious user was explicitly forced to `selectedPersonaFilter='All'` at `Dashboard.tsx:661–663`, hiding the 16-module beginner path. That override is gone, and four new components surface the persona's `recommendedPath` + `pathItems` directly.

## What changed

**P0 (4 items)**
- Remove the curious `'All'` override. Every persona starts pre-filtered to its own path.
- New `'path'` viewMode added to `LearnViewToggle`. Default per persona: researcher/null → `stack`; everyone else → `path`.
- `useLearnStore` holds the curious-only \"Show me everything (advanced)\" escape (versioned, migrated, crash-guarded per CLAUDE.md persistence conventions).
- `pathItems` checkpoint nodes render as phase boundaries through a new `usePersonaPathItems` helper. Terminal `quiz` becomes a \"Wrap-up\" phase.

**P1 (4 items)**
- `RecommendedPathBanner` above the path: persona label, module/checkpoint counts, hours, Resume → next-incomplete module.
- Sort un-disabled in cards/table when persona is active. \"Curated order\" badge + \"Reset to curated\" link replace the silent disable.
- Researcher: sort defaults to `recently`; `ContentUpdatesFeed` opens expanded.
- Standalone Common Ground callout suppressed when the path view is active for executive/curious; per-module \"Common Ground\" badge appears on each of the 5 common-ground module cards instead.

**P2 (all 4 items)**
- P2-1: Ops persona sees a \"Try in playground\" button on each module card that has a curated mapping in `moduleEnrichment.ts` (15 entries: tls-basics → tls-simulator, pki-workshop → pki-workshop, etc.).
- P2-2: Sticky phase breadcrumb at the top of the path view for ops + curious (longest paths benefit most). Current phase highlighted; completed phases use `text-status-success`; `aria-current=\"step\"`.
- P2-3: Researcher-only \"Browse by algorithm/standard\" filter chips above the stack. Selecting a taxon (e.g. ML-KEM, FIPS 203) narrows the visible modules via the existing `filteredModuleIds` set. 10 algorithm taxons, 11 standard taxons, 18 modules tagged.
- P2-4: NICE Proficiency filter hidden from curious by default in both mobile drawer and desktop popover; \"Show advanced filters\" link reveals it.

**Parallel-session ergonomics (bonus)**
- `scripts/new-worktree.sh` creates a sibling worktree at `~/antigravity/pqctoday-hub-<slug>/` on a chosen branch, symlinking the gitignored project-config files (CLAUDE.md, .claude/, sync-private.sh, tasks/). Documented in CLAUDE.md under a new \"Parallel sessions: use git worktrees\" section.
- `playwright.config.ts` reads `PLAYWRIGHT_DEV_PORT` env var so parallel worktrees can run E2E without colliding on 5175.

## Test plan

- [ ] CI green (lint, audit:matrix-refs, tsc, vitest, Playwright shards)
- [ ] Load `/learn?persona=executive` — path view renders, 6 phases, RecommendedPathBanner shows persona label + Resume button
- [ ] Load `/learn?persona=curious` — path view renders, 5 phases, \"Show me everything (advanced)\" button present
- [ ] Click \"Show me everything\" — flips to stack catalog, persists across reload
- [ ] Load `/learn?persona=researcher` — stack mode + algorithm/standard chip row above the stack
- [ ] Click \"Algorithm\" chip → listbox opens → select ML-KEM → stack narrows to ML-KEM-tagged modules
- [ ] Load `/learn?persona=ops`, expand any phase — at least one module card shows \"Try in playground\" button; clicking navigates to `/playground/<tool>`
- [ ] Load `/learn` with no persona — stack default, no path view, no regression

**Local verification already done:**
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors, 1276 warnings (none introduced)
- 37 unit tests pass across 6 files (Dashboard, PersonaPathView, RecommendedPathBanner, useLearnStore, moduleEnrichment, ResearcherTaxonomyFilter)
- 10 Playwright E2E pass against the dev server

**Plan + audit links** (in pqctoday-priv):
- Audit: `docs/platform/ux/page-audits/2026-05-22-persona-overwhelm/learn.md`
- Plan: `docs/platform/ux/page-audits/2026-05-22-persona-overwhelm/plans/learn.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)