### PR TITLE
ci: gate every active timeline row to on-disk evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,14 @@ jobs:
       - name: Audit timeline aliases
         run: npm run audit:timeline-aliases
 
+      - name: Audit timeline evidence (every active row resolves to local file)
+        # Verifies that every active row in the latest timeline_*.csv has an
+        # acceptable entry in public/timeline/evidence/manifest.json
+        # (download_status ∈ {ok, paywall, skipped}). Catches regressions
+        # where a CSV row is added without electronic evidence backing.
+        # Audit-only — no network calls, deterministic.
+        run: npm run audit:timeline-evidence
+
       - name: Audit compliance country tokens
         run: npm run audit:compliance-countries
 


### PR DESCRIPTION
## Summary

Adds `npm run audit:timeline-evidence` to the CI **checks** job, between the existing `audit:timeline-aliases` and `audit:compliance-countries` steps.

The audit verifies that every active row in the latest `src/data/timeline_*.csv` has an acceptable entry in `public/timeline/evidence/manifest.json` (`download_status ∈ {ok, paywall, skipped}`). Catches regressions where a timeline row is added without electronic-evidence backing.

The audit script is deterministic (no network calls in default mode), so the new CI step adds <1s and zero flakiness.

## Why

Closes the CI coverage gap surfaced during the 2026-05-22 timeline-evidence pipeline build. Without this gate, a future PR could add a CSV row whose `SourceUrl` is unreachable, without either an on-disk file under `public/timeline/` or a skip-list entry — and the audit fails silently only on local runs.

## Test plan

- [x] Local: `npm run audit:timeline-evidence` PASSES against current snapshot (226 active rows, all `ok`).
- [ ] CI: this PR's `checks` run executes the new step and reports PASS.
- [ ] (Negative confirmation, optional) Temporarily add a row with a bogus URL on a branch → audit should FAIL the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)