### PR TITLE
feat(personas): overwhelm rollout — Migrate / Assess / Playground / Threats / Timeline + nav + scaffolding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## What's new — May 22, 2026 (evening)
+
+Seven additions completing the persona-overwhelm initiative across the remaining 5 pages:
+
+- **Migrate's product catalog now narrows by persona on first paint.** Executive lands on ~134 products in Cloud + AppServers (was 832 unfiltered). Developer lands on Libraries + Cloud + Database. Architect on Cloud + Network + AppServers + Security Stack. Ops on Network + Hardware + OS + Security Stack. Researcher + curious see the full corpus unchanged. A "Showing N products matched to your role · See all 832" banner appears whenever narrowing is active; one click writes `?prefs=off` and shows the full catalog. `PERSONA_MIGRATE_LAYERS` was always defined; the renderer was only using it as a sort tiebreaker — now it filters.
+- **Assess wizard auto-skips the mode picker when the persona implies the answer.** Executive + curious land directly inside Quick wizard. Developer / architect / researcher / ops land directly inside Comprehensive. A "Switch to {Comprehensive|Quick} mode" link is rendered above the wizard for users who want the other path. `?prefs=off` opts back to the ModeSelector. Wired via render-time derivation (not a useEffect) to avoid a state-propagation race.
+- **Playground gates the 35-tool grid behind a disclosure for curious users.** Curious now lands on the existing `CuriousStartHere` 3-step orientation panel as the page (not above the grid as before). A "Show full catalog (35 tools)" button reveals the sidebar + filters + grid on click and sets `?prefs=off`. Other personas see the full catalog unchanged — no behavior change for developer / architect / researcher / ops / executive.
+- **Threats now respects persona alone (no industry pick required).** New `PERSONA_THREATS_DEFAULT_INDUSTRIES` constant: executive → Finance & Banking + Government & Defense, developer → Technology, architect → Technology + Telecommunications, ops → Energy & Utilities + Telecommunications, researcher + curious → no narrowing. Previously the page rendered all 54 threats when no industry was picked, even if the user had selected a persona. Now executive lands on ~12 high-impact threats matched to Finance + Gov.
+- **Timeline lands every persona on a region-relevant slice instead of the full 40-country wall.** New `PERSONA_TIMELINE_REGION` constant: executive / developer / ops / curious → Americas, architect → Global, researcher → All (full corpus, preserved). URL `?region=` deep-link still wins; users who already set `selectedRegion` in their profile see that. Folded into the existing URL-sync `useEffect` so the persona default isn't overwritten on every re-render.
+- **`/openssl` nav-path fix.** Was incorrectly listed in `PERSONA_NAV_PATHS.curious` (sends users with "no technical background" to a CLI) and absent from `architect` (the persona most likely to use OpenSSL for crypto-agility planning). Two-line fix.
+- **Shared scaffolding for the "persona-aware default filter" pattern.** New `<PersonaDefaultsBanner>` + `usePersonaDefaults()` hook lifted out of LibraryView so the 4 new page integrations + the existing one all speak the same UX (banner copy, `?prefs=off` URL convention, persona-change reset behavior). LibraryView refactored to consume them; 65 existing Library tests pass without modification.
+
+The persona-overwhelm initiative is now complete for the 5 pages in scope. Two items are deferred to a follow-up PR: Timeline's `EventTypeFilter` component (needs a new CSV `category` column or string-inference classifier) and Leaders' curated top-15 (editorial work, list TBD).
+
+---
+
 ## What's new — May 22, 2026
 
 Six additions across the Playground, Algorithms, Report, and Library:

--- a/e2e/assess-persona-defaults.spec.ts
+++ b/e2e/assess-persona-defaults.spec.ts
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-3.0-only
+import { test, expect } from '@playwright/test'
+
+/**
+ * Persona-overwhelm audit acceptance — /assess page.
+ *
+ * Goal (per audit `pqctoday-priv/docs/platform/ux/page-audits/
+ * 2026-05-22-persona-overwhelm/assess.md`): PERSONA_RECOMMENDED_MODE was
+ * only consumed as a "Recommended" badge on the mode-selector cards; the
+ * wizard still forced every persona to click a mode tile before starting.
+ *
+ * After this rollout, when a persona resolves a recommended mode AND no
+ * prior `assessmentMode` is in the persisted store AND no URL override
+ * is present, the page auto-skips ModeSelector and drops the user
+ * straight into AssessWizard. A "Switch mode" link is always available.
+ *
+ * Executive's recommended mode is 'quick'.
+ * Developer/architect/researcher/ops's recommended mode is 'comprehensive'.
+ */
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'pqc-disclaimer-storage',
+      JSON.stringify({ state: { acknowledgedMajorVersion: 99 }, version: 0 })
+    )
+    localStorage.setItem(
+      'pqc-version-storage',
+      JSON.stringify({ state: { lastSeenVersion: '99.0.0' }, version: 0 })
+    )
+  })
+})
+
+test('executive persona auto-skips ModeSelector and lands in Quick wizard', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'pqc-learning-persona',
+      JSON.stringify({
+        state: {
+          selectedPersona: 'executive',
+          selectedRegion: 'global',
+          selectedIndustry: null,
+          selectedIndustries: [],
+          experienceLevel: 'expert',
+          viewAccess: { allowed: [] },
+        },
+        version: 0,
+      })
+    )
+  })
+
+  await page.goto('/assess')
+
+  // The "Switch mode" link with our testid is the sentinel — present only
+  // when AssessWizard is rendered (i.e. assessmentMode has been set).
+  const switchModeLink = page.getByTestId('assess-switch-mode')
+  await expect(switchModeLink).toBeVisible({ timeout: 15000 })
+
+  // Confirm the user is in Quick mode (executive's recommendation).
+  await expect(switchModeLink).toHaveText(/Switch to comprehensive mode/i)
+
+  // ModeSelector cards are identified by `data-workshop-target="assess-mode-quick"`.
+  // After auto-skip, they should NOT render.
+  await expect(page.locator('[data-workshop-target="assess-mode-quick"]')).toHaveCount(0)
+})
+
+test('Switch mode link returns the user to ModeSelector', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'pqc-learning-persona',
+      JSON.stringify({
+        state: {
+          selectedPersona: 'executive',
+          selectedRegion: 'global',
+          selectedIndustry: null,
+          selectedIndustries: [],
+          experienceLevel: 'expert',
+          viewAccess: { allowed: [] },
+        },
+        version: 0,
+      })
+    )
+  })
+
+  await page.goto('/assess')
+
+  const switchModeLink = page.getByTestId('assess-switch-mode')
+  await expect(switchModeLink).toBeVisible({ timeout: 15000 })
+
+  await switchModeLink.click()
+
+  // After clicking, ?prefs=off is set and the wizard's switch-mode link
+  // disappears (only renders when effectiveAssessmentMode is truthy, which
+  // is no longer true once prefs=off opts out of the persona auto-skip).
+  await expect(page).toHaveURL(/[?&]prefs=off(&|$)/, { timeout: 5000 })
+  await expect(switchModeLink).not.toBeVisible({ timeout: 5000 })
+})
+
+test('?prefs=off keeps ModeSelector visible for executive', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'pqc-learning-persona',
+      JSON.stringify({
+        state: {
+          selectedPersona: 'executive',
+          selectedRegion: 'global',
+          selectedIndustry: null,
+          selectedIndustries: [],
+          experienceLevel: 'expert',
+          viewAccess: { allowed: [] },
+        },
+        version: 0,
+      })
+    )
+  })
+
+  await page.goto('/assess?prefs=off')
+
+  // With ?prefs=off the persona auto-skip is bypassed; ModeSelector renders.
+  await expect(page.locator('[data-workshop-target="assess-mode-quick"]')).toBeVisible({
+    timeout: 15000,
+  })
+})

--- a/e2e/migrate-persona-defaults.spec.ts
+++ b/e2e/migrate-persona-defaults.spec.ts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-3.0-only
+import { test, expect } from '@playwright/test'
+
+/**
+ * Persona-overwhelm audit acceptance — /migrate page.
+ *
+ * Goal (per audit `pqctoday-priv/docs/platform/ux/page-audits/
+ * 2026-05-22-persona-overwhelm/migrate.md`): wire `PERSONA_MIGRATE_LAYERS`
+ * as a default infrastructure-layer filter (was a sort tiebreaker only).
+ *
+ * Executive's preferred layers = `['Cloud', 'AppServers']`. With persona
+ * narrowing active, the first-paint product count should be materially
+ * below the ~235 full-catalog count, the `PersonaDefaultsBanner` should
+ * render, and clicking "See all N" should write `?prefs=off` to the URL
+ * and remove the banner.
+ *
+ * Researcher (empty PERSONA_MIGRATE_LAYERS) is asserted in a second test
+ * to confirm the audit's AC-5 "no regression" guarantee.
+ */
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    // Suppress disclaimer + WhatsNew overlays that intercept clicks.
+    localStorage.setItem(
+      'pqc-disclaimer-storage',
+      JSON.stringify({ state: { acknowledgedMajorVersion: 99 }, version: 0 })
+    )
+    localStorage.setItem(
+      'pqc-version-storage',
+      JSON.stringify({ state: { lastSeenVersion: '99.0.0' }, version: 0 })
+    )
+  })
+})
+
+test('executive persona narrows /migrate first-paint and reset link works', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'pqc-learning-persona',
+      JSON.stringify({
+        state: {
+          selectedPersona: 'executive',
+          selectedRegion: 'global',
+          selectedIndustry: null,
+          selectedIndustries: [],
+          experienceLevel: 'expert',
+          viewAccess: { allowed: [] },
+        },
+        version: 0,
+      })
+    )
+  })
+
+  await page.goto('/migrate')
+
+  // PersonaDefaultsBanner is keyed by role="status". The "See all N"
+  // reset link inside it is a Button — match by its accessible name.
+  // Cards mode is the default viewMode, so the banner mounts above the
+  // CatalogSizeBanner inside the desktop shell.
+  const banner = page
+    .getByRole('status')
+    .filter({ hasText: /matched to your role/i })
+    .first()
+  await expect(banner).toBeVisible({ timeout: 15000 })
+
+  // Banner text format: "Showing N products matched to your role · See all M".
+  // M = full catalog (softwareData.length). N < M is the persona-narrowing
+  // claim. We don't pin N exactly because the catalog grows; instead assert
+  // matched < total and matched > 0 (executive has 2 preferred layers, so
+  // there are always some products).
+  const bannerText = await banner.textContent()
+  // Note: react renders the middot separator as a sibling span; textContent
+  // collapses sibling whitespace so the actual string has no spaces around `·`.
+  const match = bannerText?.match(
+    /Showing (\d+) products? matched to your role\s*·\s*See all (\d+)/
+  )
+  expect(match, `banner text: ${bannerText ?? '(null)'}`).not.toBeNull()
+  const matched = parseInt(match![1], 10)
+  const total = parseInt(match![2], 10)
+  expect(matched).toBeGreaterThan(0)
+  expect(matched).toBeLessThan(total)
+
+  // Click "See all N" — the reset link inside the banner.
+  await banner.getByRole('button', { name: /^See all \d+$/ }).click()
+
+  // URL gains ?prefs=off; banner disappears.
+  await expect(page).toHaveURL(/[?&]prefs=off(&|$)/, { timeout: 5000 })
+  await expect(banner).not.toBeVisible()
+})
+
+test('researcher persona does not narrow /migrate (no banner)', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'pqc-learning-persona',
+      JSON.stringify({
+        state: {
+          selectedPersona: 'researcher',
+          selectedRegion: 'global',
+          selectedIndustry: null,
+          selectedIndustries: [],
+          experienceLevel: 'expert',
+          viewAccess: { allowed: [] },
+        },
+        version: 0,
+      })
+    )
+  })
+
+  await page.goto('/migrate')
+
+  // Wait for the page to mount — the catalog size banner is the natural
+  // sentinel since it always renders.
+  const catalogBanner = page.getByText(/of \d+ products/i).first()
+  await expect(catalogBanner).toBeVisible({ timeout: 15000 })
+
+  // Researcher's PERSONA_MIGRATE_LAYERS is empty by design → no narrowing
+  // → PersonaDefaultsBanner must NOT render.
+  const banner = page.getByRole('status').filter({ hasText: /matched to your role/i })
+  await expect(banner).toHaveCount(0)
+})

--- a/e2e/playground-curious-mode.spec.ts
+++ b/e2e/playground-curious-mode.spec.ts
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-3.0-only
+import { test, expect } from '@playwright/test'
+
+/**
+ * Persona-overwhelm audit acceptance — /playground curious mode.
+ *
+ * Goal (per audit `pqctoday-priv/docs/platform/ux/page-audits/
+ * 2026-05-22-persona-overwhelm/playground.md`): the 35-tool grid + raw
+ * byte output panes are hostile to the curious persona. Replace the
+ * catalog UI with a 3-step CuriousStartHere panel; render a "Show full
+ * catalog" CTA that opts the user into the full catalog via ?prefs=off.
+ *
+ * Other personas (executive/developer/architect/researcher/ops) see the
+ * full catalog unchanged.
+ */
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'pqc-disclaimer-storage',
+      JSON.stringify({ state: { acknowledgedMajorVersion: 99 }, version: 0 })
+    )
+    localStorage.setItem(
+      'pqc-version-storage',
+      JSON.stringify({ state: { lastSeenVersion: '99.0.0' }, version: 0 })
+    )
+  })
+})
+
+test('curious persona sees CuriousStartHere only; catalog gated behind disclosure', async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'pqc-learning-persona',
+      JSON.stringify({
+        state: {
+          selectedPersona: 'curious',
+          selectedRegion: 'global',
+          selectedIndustry: null,
+          selectedIndustries: [],
+          experienceLevel: 'awareness',
+          viewAccess: { allowed: [] },
+        },
+        version: 0,
+      })
+    )
+  })
+
+  await page.goto('/playground')
+
+  // "Show full catalog (N tools)" CTA is the sentinel for curious minimal mode.
+  const cta = page.getByTestId('playground-show-full-catalog')
+  await expect(cta).toBeVisible({ timeout: 15000 })
+
+  // CTA label includes the workshop-tool count.
+  await expect(cta).toHaveText(/Show full catalog \(\d+ tools\)/i)
+
+  // The category sidebar ("All tools" pill) is part of the catalog UI and
+  // must NOT be in the DOM in curious minimal mode.
+  const categoryAllToolsPill = page.getByRole('button', { name: /^All tools \d+$/ })
+  await expect(categoryAllToolsPill).toHaveCount(0)
+
+  // Click the CTA → ?prefs=off in URL, catalog reveals.
+  await cta.click()
+  await expect(page).toHaveURL(/[?&]prefs=off(&|$)/, { timeout: 5000 })
+
+  // After opt-in, the catalog sidebar appears.
+  await expect(categoryAllToolsPill.first()).toBeVisible({ timeout: 5000 })
+  // The CTA itself goes away (no longer needed once user opted in).
+  await expect(cta).not.toBeVisible()
+})
+
+test('developer persona sees full catalog (no curious gate)', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'pqc-learning-persona',
+      JSON.stringify({
+        state: {
+          selectedPersona: 'developer',
+          selectedRegion: 'global',
+          selectedIndustry: null,
+          selectedIndustries: [],
+          experienceLevel: 'expert',
+          viewAccess: { allowed: [] },
+        },
+        version: 0,
+      })
+    )
+  })
+
+  await page.goto('/playground')
+
+  // Category sidebar appears immediately — full catalog rendered.
+  const categoryAllToolsPill = page.getByRole('button', { name: /^All tools \d+$/ }).first()
+  await expect(categoryAllToolsPill).toBeVisible({ timeout: 15000 })
+
+  // The curious-mode CTA is absent for non-curious personas.
+  await expect(page.getByTestId('playground-show-full-catalog')).toHaveCount(0)
+})

--- a/e2e/threats-persona-defaults.spec.ts
+++ b/e2e/threats-persona-defaults.spec.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-3.0-only
+import { test, expect } from '@playwright/test'
+
+/**
+ * Persona-overwhelm audit acceptance — /threats page.
+ *
+ * Goal (per audit `pqctoday-priv/docs/platform/ux/page-audits/
+ * 2026-05-22-persona-overwhelm/threats.md`): when a persona is set but
+ * no industry is picked, the page rendered the full threat corpus
+ * unfiltered. The new PERSONA_THREATS_DEFAULT_INDUSTRIES constant
+ * provides sensible per-persona default industries; the dashboard now
+ * narrows the corpus to those industries on first paint.
+ *
+ * Executive's default = ['Finance & Banking', 'Government & Defense']
+ * Researcher's default = [] (full corpus, no narrowing — AC-5 invariant).
+ */
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'pqc-disclaimer-storage',
+      JSON.stringify({ state: { acknowledgedMajorVersion: 99 }, version: 0 })
+    )
+    localStorage.setItem(
+      'pqc-version-storage',
+      JSON.stringify({ state: { lastSeenVersion: '99.0.0' }, version: 0 })
+    )
+  })
+})
+
+test('executive persona (no industry picked) narrows /threats and reset works', async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'pqc-learning-persona',
+      JSON.stringify({
+        state: {
+          selectedPersona: 'executive',
+          selectedRegion: 'global',
+          // selectedIndustry intentionally null + selectedIndustries empty so
+          // the persona-default kicks in.
+          selectedIndustry: null,
+          selectedIndustries: [],
+          experienceLevel: 'expert',
+          viewAccess: { allowed: [] },
+        },
+        version: 0,
+      })
+    )
+  })
+
+  await page.goto('/threats')
+
+  // PersonaDefaultsBanner is keyed by role="status".
+  const banner = page
+    .getByRole('status')
+    .filter({ hasText: /matched to your role/i })
+    .first()
+  await expect(banner).toBeVisible({ timeout: 15000 })
+
+  const bannerText = await banner.textContent()
+  const match = bannerText?.match(/Showing (\d+) threats? matched to your role\s*·\s*See all (\d+)/)
+  expect(match, `banner text: ${bannerText ?? '(null)'}`).not.toBeNull()
+  const matched = parseInt(match![1], 10)
+  const total = parseInt(match![2], 10)
+  expect(matched).toBeGreaterThan(0)
+  expect(matched).toBeLessThan(total)
+
+  // Click "See all N" — sets ?prefs=off, banner disappears.
+  await banner.getByRole('button', { name: /^See all \d+$/ }).click()
+  await expect(page).toHaveURL(/[?&]prefs=off(&|$)/, { timeout: 5000 })
+  await expect(banner).not.toBeVisible()
+})
+
+test('researcher persona (no industry picked) does not narrow /threats', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'pqc-learning-persona',
+      JSON.stringify({
+        state: {
+          selectedPersona: 'researcher',
+          selectedRegion: 'global',
+          selectedIndustry: null,
+          selectedIndustries: [],
+          experienceLevel: 'expert',
+          viewAccess: { allowed: [] },
+        },
+        version: 0,
+      })
+    )
+  })
+
+  await page.goto('/threats')
+
+  // Wait for the page to mount.
+  const pageHeader = page.getByRole('heading', { name: /Quantum Threats/i })
+  await expect(pageHeader).toBeVisible({ timeout: 15000 })
+
+  // Researcher has no default industries → no banner.
+  const banner = page.getByRole('status').filter({ hasText: /matched to your role/i })
+  await expect(banner).toHaveCount(0)
+})

--- a/e2e/timeline-persona-region.spec.ts
+++ b/e2e/timeline-persona-region.spec.ts
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: GPL-3.0-only
+import { test, expect } from '@playwright/test'
+
+/**
+ * Persona-overwhelm audit acceptance — /timeline page (region defaults only).
+ *
+ * Goal (per audit `pqctoday-priv/docs/platform/ux/page-audits/
+ * 2026-05-22-persona-overwhelm/timeline.md`): every persona landed on the
+ * same 40-country Gantt chart regardless of role. The new
+ * PERSONA_TIMELINE_REGION constant provides a sensible default region
+ * per persona; TimelineView's regionFilter initialiser consumes it when
+ * no URL deep-link / persona-store region / ?prefs=off opt-out is present.
+ *
+ * Scope of this PR: region default only. The audit also asked for an
+ * `EventTypeFilter` (Mandate/Standard/Guidance/Industry), which requires
+ * a new CSV column and is deferred to a follow-up.
+ */
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'pqc-disclaimer-storage',
+      JSON.stringify({ state: { acknowledgedMajorVersion: 99 }, version: 0 })
+    )
+    localStorage.setItem(
+      'pqc-version-storage',
+      JSON.stringify({ state: { lastSeenVersion: '99.0.0' }, version: 0 })
+    )
+  })
+})
+
+test('developer persona without stored region lands on Americas timeline by default', async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'pqc-learning-persona',
+      JSON.stringify({
+        state: {
+          selectedPersona: 'developer',
+          // selectedRegion: null — explicit so the PERSONA_TIMELINE_REGION
+          // fallback path is exercised. Developer's default = 'americas'.
+          selectedRegion: null,
+          selectedIndustry: null,
+          selectedIndustries: [],
+          experienceLevel: 'expert',
+          viewAccess: { allowed: [] },
+        },
+        version: 0,
+      })
+    )
+  })
+
+  await page.goto('/timeline')
+
+  // Wait for the page to mount.
+  await expect(page.getByRole('heading', { name: /Migration timeline/i })).toBeVisible({
+    timeout: 15000,
+  })
+
+  // The region pill for Americas should be `aria-pressed="true"` (active)
+  // when the persona-default region applied.
+  const americasPill = page.getByRole('button', { pressed: true, name: /Americas/i }).first()
+  await expect(americasPill).toBeVisible({ timeout: 10000 })
+})
+
+test('researcher persona lands on All regions (no narrowing)', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'pqc-learning-persona',
+      JSON.stringify({
+        state: {
+          selectedPersona: 'researcher',
+          selectedRegion: null,
+          selectedIndustry: null,
+          selectedIndustries: [],
+          experienceLevel: 'expert',
+          viewAccess: { allowed: [] },
+        },
+        version: 0,
+      })
+    )
+  })
+
+  await page.goto('/timeline')
+
+  await expect(page.getByRole('heading', { name: /Migration timeline/i })).toBeVisible({
+    timeout: 15000,
+  })
+
+  // Researcher's PERSONA_TIMELINE_REGION = 'All' → no region pill is
+  // aria-pressed.
+  const anyActiveRegionPill = page.getByRole('button', {
+    pressed: true,
+    name: /Americas|EU|MENA|APAC|Global/i,
+  })
+  await expect(anyActiveRegionPill).toHaveCount(0)
+})
+
+test('?region=eu deep-link wins over persona default for developer', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'pqc-learning-persona',
+      JSON.stringify({
+        state: {
+          selectedPersona: 'developer',
+          selectedRegion: null,
+          selectedIndustry: null,
+          selectedIndustries: [],
+          experienceLevel: 'expert',
+          viewAccess: { allowed: [] },
+        },
+        version: 0,
+      })
+    )
+  })
+
+  await page.goto('/timeline?region=eu')
+
+  await expect(page.getByRole('heading', { name: /Migration timeline/i })).toBeVisible({
+    timeout: 15000,
+  })
+
+  // URL deep-link wins: EU pill is active even though developer's
+  // persona default would have been Americas.
+  const euPill = page.getByRole('button', { pressed: true, name: /EU/i }).first()
+  await expect(euPill).toBeVisible({ timeout: 5000 })
+})

--- a/src/components/Assess/AssessView.tsx
+++ b/src/components/Assess/AssessView.tsx
@@ -96,7 +96,7 @@ const ModeSelector: React.FC<{
 
 export const AssessView: React.FC = () => {
   const navigate = useNavigate()
-  const [searchParams] = useSearchParams()
+  const [searchParams, setSearchParams] = useSearchParams()
   const {
     assessmentStatus,
     markComplete,
@@ -130,6 +130,28 @@ export const AssessView: React.FC = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams])
+
+  // Persona-aware mode auto-skip — when the user has a persona with a
+  // recommended mode (PERSONA_RECOMMENDED_MODE) and no prior mode is set,
+  // skip the ModeSelector step and drop directly into the wizard.
+  // Respects:
+  //   - `?mode=` URL param (handled by the effect above, wins).
+  //   - `?prefs=off` URL param: shows ModeSelector even when persona
+  //     resolves a recommendation (user opted out via Switch-mode link).
+  //   - Prior `assessmentMode` in the persisted store (user already chose).
+  //
+  // Derived purely at render time (no useEffect). This avoids a race where
+  // the click handler on "Switch mode" sets both `?prefs=off` AND clears
+  // the mode, but an effect with stale deps re-applies the recommendation
+  // before the URL update propagates. Render-time derivation reads the
+  // current values atomically.
+  const personaAutoSkipApplies =
+    !assessmentMode &&
+    !!recommendedMode &&
+    searchParams.get('prefs') !== 'off' &&
+    !searchParams.get('mode')
+  const effectiveAssessmentMode =
+    assessmentMode ?? (personaAutoSkipApplies ? recommendedMode : null)
 
   // Command Center is only shown to executive / architect / ops personas.
   const personaSeesBusinessCenter = selectedPersona
@@ -276,10 +298,44 @@ export const AssessView: React.FC = () => {
         </motion.div>
       )}
 
-      {!assessmentMode ? (
+      {!effectiveAssessmentMode ? (
         <ModeSelector onSelect={handleModeSelect} recommendedMode={recommendedMode} />
       ) : (
-        <AssessWizard onComplete={handleComplete} mode={assessmentMode} />
+        <>
+          {/* "Switch mode" escape — always visible alongside the wizard so
+              the user can change mode without picking through the store.
+              Persona-auto-skipped users see it most prominently; users who
+              actively chose see it as a non-intrusive secondary link. */}
+          {recommendedMode && (
+            <div className="mb-3 text-xs text-muted-foreground">
+              You're in <span className="font-medium">{effectiveAssessmentMode}</span> mode.{' '}
+              <Button
+                variant="link"
+                className="text-xs h-auto p-0 align-baseline"
+                onClick={() => {
+                  // Set ?prefs=off so the render-time auto-skip computes
+                  // `effectiveAssessmentMode === null` and ModeSelector
+                  // renders again. Also clear the persisted assessmentMode
+                  // so the user can re-pick (the wizard reads from `mode`
+                  // prop which derives from effectiveAssessmentMode).
+                  setSearchParams(
+                    (prev) => {
+                      const next = new URLSearchParams(prev)
+                      next.set('prefs', 'off')
+                      return next
+                    },
+                    { replace: true }
+                  )
+                  setAssessmentMode(null)
+                }}
+                data-testid="assess-switch-mode"
+              >
+                Switch to {effectiveAssessmentMode === 'quick' ? 'comprehensive' : 'quick'} mode
+              </Button>
+            </div>
+          )}
+          <AssessWizard onComplete={handleComplete} mode={effectiveAssessmentMode} />
+        </>
       )}
     </div>
   )

--- a/src/components/Library/LibraryView.tsx
+++ b/src/components/Library/LibraryView.tsx
@@ -18,6 +18,8 @@ import type { ViewMode } from './ViewToggle'
 import { SortControl } from './SortControl'
 import type { SortOption } from './SortControl'
 import { FilterDropdown } from '../common/FilterDropdown'
+import { PersonaDefaultsBanner } from '../common/PersonaDefaultsBanner'
+import { usePersonaDefaults } from '@/hooks/usePersonaDefaults'
 import { Search, FileSearch, BookOpen, SlidersHorizontal, X, BookmarkCheck } from 'lucide-react'
 import { PageHeader } from '../common/PageHeader'
 import { ContentUpdatesFeed } from '@/components/ui/ContentUpdatesFeed'
@@ -490,31 +492,17 @@ export const LibraryView: React.FC = () => {
 
   // Persona-preferred set — used as a default multi-category filter when
   // the user has not picked an explicit category. Researcher's empty array
-  // short-circuits to "no narrowing". ?prefs=off opts back to the full corpus.
+  // short-circuits to "no narrowing". `usePersonaDefaults()` owns the
+  // ?prefs=off URL state and the persona-change reset that previously
+  // lived inline here. See `@/hooks/usePersonaDefaults`.
+  const personaDefaults = usePersonaDefaults()
   const personaPreferredCategories = useMemo<string[]>(() => {
-    if (searchParams.get('prefs') === 'off') return []
+    if (personaDefaults.prefsOff) return []
     if (!selectedPersona) return []
     return PERSONA_LIBRARY_CATEGORIES[selectedPersona] ?? [] // eslint-disable-line security/detect-object-injection
-  }, [selectedPersona, searchParams])
+  }, [selectedPersona, personaDefaults.prefsOff])
 
   const personaPreferredActive = personaPreferredCategories.length > 0 && activeCategory === 'All'
-
-  // When persona changes, the user has effectively asked for a new set of
-  // defaults — strip a lingering ?prefs=off so the new persona's preferred
-  // narrowing applies.
-  useEffect(() => {
-    if (searchParams.get('prefs') === 'off') {
-      setSearchParams(
-        (prev) => {
-          const next = new URLSearchParams(prev)
-          next.delete('prefs')
-          return next
-        },
-        { replace: true }
-      )
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedPersona])
 
   // Phase 3 — semantic search supplement. The hook returns ranked
   // referenceIds when the embedding runtime is ready. The lexical
@@ -1227,30 +1215,15 @@ export const LibraryView: React.FC = () => {
       {showFullPage && (
         <div className="space-y-1" role="status" aria-live="polite">
           {personaPreferredActive ? (
-            <div className="glass-panel inline-flex flex-wrap items-center gap-2 px-3 py-1.5 rounded-md text-xs">
-              <span className="text-muted-foreground">
-                Showing {filteredItems.length} document{filteredItems.length !== 1 ? 's' : ''}{' '}
-                matched to your role
-              </span>
-              <span className="text-muted-foreground/60">·</span>
-              <Button
-                variant="link"
-                onClick={() => {
-                  setSearchParams(
-                    (prev) => {
-                      const next = new URLSearchParams(prev)
-                      next.set('prefs', 'off')
-                      return next
-                    },
-                    { replace: true }
-                  )
-                  logEvent('Library', 'Persona Prefs Off', personaLabel())
-                }}
-                className="text-xs h-auto p-0"
-              >
-                See all {libraryData.length}
-              </Button>
-            </div>
+            <PersonaDefaultsBanner
+              matchedCount={filteredItems.length}
+              totalCount={libraryData.length}
+              noun="document"
+              onReset={() => {
+                personaDefaults.resetToFullSet()
+                logEvent('Library', 'Persona Prefs Off', personaLabel())
+              }}
+            />
           ) : (
             <p className="text-xs text-muted-foreground">
               {filteredItems.length} document{filteredItems.length !== 1 ? 's' : ''}

--- a/src/components/Migrate/MigrateView.tsx
+++ b/src/components/Migrate/MigrateView.tsx
@@ -43,6 +43,8 @@ import { useWorkflowPhaseTracker } from '@/hooks/useWorkflowPhaseTracker'
 import { useHistoryStore } from '@/store/useHistoryStore'
 import { usePersonaStore } from '@/store/usePersonaStore'
 import { PERSONA_MIGRATE_LAYERS } from '@/data/personaConfig'
+import { PersonaDefaultsBanner } from '@/components/common/PersonaDefaultsBanner'
+import { usePersonaDefaults } from '@/hooks/usePersonaDefaults'
 import { useSemanticSearch } from '@/services/search/useSemanticSearch'
 import { SemanticSearchHint } from '@/components/common/SemanticSearchHint'
 import { Button } from '../ui/button'
@@ -85,6 +87,7 @@ export const MigrateView: React.FC = () => {
   const addHistoryEvent = useHistoryStore((s) => s.addEvent)
   const persona = usePersonaStore((s) => s.selectedPersona)
   const preferredLayers = persona ? (PERSONA_MIGRATE_LAYERS[persona] ?? []) : [] // eslint-disable-line security/detect-object-injection
+  const personaDefaults = usePersonaDefaults()
   const [searchParams, setSearchParams] = useSearchParams()
   const [filterText, setFilterText] = useState(() => searchParams.get('q') ?? '')
   const [inputValue, setInputValue] = useState(() => searchParams.get('q') ?? '')
@@ -445,6 +448,14 @@ export const MigrateView: React.FC = () => {
       : activeLayer
   const effectiveSubCategory = urlSubcatParam ?? activeSubCategory
 
+  // Persona-aware default narrowing. Active when the persona has a preferred
+  // infrastructure-layer set, the user hasn't picked an explicit layer (or
+  // opted out via ?prefs=off), and we're in a flat view (the per-layer
+  // grouped views already isolate layers by construction).
+  // Researcher + curious have empty PERSONA_MIGRATE_LAYERS → no narrowing.
+  const personaDefaultActive =
+    preferredLayers.length > 0 && effectiveLayer === 'All' && !personaDefaults.prefsOff
+
   const activeInfrastructureLayer = effectiveLayer as string
   const activeTab = effectiveSubCategory
   const hiddenSet = useMemo(() => new Set(hiddenProducts), [hiddenProducts])
@@ -784,6 +795,11 @@ export const MigrateView: React.FC = () => {
           const itemLayers = item.infrastructureLayer.split(',').map((l) => l.trim())
           if (!itemLayers.includes(effectiveLayer)) return false
         }
+      } else if (personaDefaultActive) {
+        // Persona-default narrowing — applies only when the user hasn't
+        // picked an explicit layer. Keeps items whose infrastructure layer
+        // overlaps with the persona's preferred set.
+        if (!isPersonaRelevant(item, preferredLayers)) return false
       }
       // Category filter (from dropdown in flat modes)
       if (flatCategoryFilter !== 'All') {
@@ -844,6 +860,9 @@ export const MigrateView: React.FC = () => {
     showOnlyMyProducts,
     myProductsSet,
     tierFilter,
+    personaDefaultActive,
+    preferredLayers,
+    effectiveViewMode,
   ])
 
   // PQC stats for all filtered products
@@ -1614,6 +1633,23 @@ export const MigrateView: React.FC = () => {
           </div>
         )}
       </div>
+
+      {/* Persona-aware default-filter banner — appears when persona narrowing
+          is active (preferred layers set + no explicit layer chosen + no
+          ?prefs=off). One click on "See all" resets to the full catalog. */}
+      {personaDefaultActive && (
+        <div className="mb-2">
+          <PersonaDefaultsBanner
+            matchedCount={allFilteredProducts.length}
+            totalCount={softwareData.length}
+            noun="product"
+            onReset={() => {
+              personaDefaults.resetToFullSet()
+              logMigrateAction('Persona Prefs Off', persona ?? '(none)')
+            }}
+          />
+        </div>
+      )}
 
       {/* Catalog size banner — visible count + view-switch CTA */}
       <CatalogSizeBanner

--- a/src/components/Playground/PlaygroundWorkshop.tsx
+++ b/src/components/Playground/PlaygroundWorkshop.tsx
@@ -28,6 +28,7 @@ import { useBookmarkStore } from '@/store/useBookmarkStore'
 import { logEvent, personaLabel } from '@/utils/analytics'
 import { getCuriousToolDescription } from '@/data/playgroundCuriousDescriptions'
 import type { PersonaId } from '@/data/learningPersonas'
+import { usePersonaDefaults } from '@/hooks/usePersonaDefaults'
 import { useIsEmbedded } from '../../embed/EmbedProvider'
 
 // ---------------------------------------------------------------------------
@@ -393,6 +394,14 @@ export const PlaygroundWorkshop = () => {
   const isPersonaFiltered =
     showPersonaFilter && !!selectedPersona && !searchQuery.trim() && !activeCategory
 
+  // Curious minimum-viable mode (persona-overwhelm rollout): for curious
+  // users, the 35-tool grid with raw byte panes is hostile on first paint.
+  // Replace the catalog UI (sidebar + search + filters + grid) with the
+  // 3-step CuriousStartHere panel and a single "Show full catalog" CTA.
+  // ?prefs=off opts out (the user has explicitly chosen to see the catalog).
+  const personaDefaults = usePersonaDefaults()
+  const curiousMinimalMode = selectedPersona === 'curious' && !personaDefaults.prefsOff
+
   return (
     <div>
       <PageHeader
@@ -408,326 +417,356 @@ export const PlaygroundWorkshop = () => {
         <PreviewBanner pageContext="Developer, Architect, Ops, Researcher" />
       )}
 
-      {/* Two-column layout on desktop: sticky left category sidebar + main content */}
-      <div className="flex gap-6 items-start">
-        {/* ── Left category sidebar (desktop only) ── */}
-        <aside
-          className="hidden lg:block w-44 shrink-0 sticky top-20 space-y-0.5"
-          aria-label="Filter by category"
-        >
-          <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground px-2 mb-2">
-            Category
-          </p>
-          <Button
-            variant="ghost"
-            onClick={() => setActiveCategory(null)}
-            className={`w-full justify-between text-xs px-2 py-1.5 h-auto rounded font-medium transition-colors ${
-              activeCategory === null
-                ? 'bg-primary/10 text-primary'
-                : 'text-muted-foreground hover:text-foreground hover:bg-muted/40'
-            }`}
-          >
-            <span>All tools</span>
-            <span
-              className={`text-[10px] tabular-nums ${activeCategory === null ? 'text-primary' : 'text-muted-foreground/60'}`}
+      {/* Curious minimum-viable mode — show only orientation + CTA. */}
+      {curiousMinimalMode && (
+        <div className="space-y-4 mt-6">
+          <CuriousStartHere />
+          <div className="flex justify-center">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                personaDefaults.resetToFullSet()
+                logEvent('Playground', 'Curious Show Full Catalog', personaLabel())
+              }}
+              data-testid="playground-show-full-catalog"
             >
-              {WORKSHOP_TOOLS.length}
-            </span>
-          </Button>
-          {CATEGORIES.map((cat) => {
-            const count = WORKSHOP_TOOLS.filter((t) => t.category === cat).length
-            const isActive = activeCategory === cat
-            return (
-              <Button
-                variant="ghost"
-                key={cat}
-                onClick={() => setActiveCategory(isActive ? null : cat)}
-                className={`w-full justify-between text-xs px-2 py-1.5 h-auto rounded font-medium transition-colors ${
-                  isActive
-                    ? 'bg-primary/10 text-primary'
-                    : 'text-muted-foreground hover:text-foreground hover:bg-muted/40'
-                }`}
+              Show full catalog ({WORKSHOP_TOOLS.length} tools)
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground text-center">
+            The full crypto lab is built for developers, architects, ops, and researchers. The 3
+            steps above are the curated entry path for curious users.
+          </p>
+        </div>
+      )}
+
+      {/* Two-column layout on desktop: sticky left category sidebar + main content */}
+      {!curiousMinimalMode && (
+        <div className="flex gap-6 items-start">
+          {/* ── Left category sidebar (desktop only) ── */}
+          <aside
+            className="hidden lg:block w-44 shrink-0 sticky top-20 space-y-0.5"
+            aria-label="Filter by category"
+          >
+            <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground px-2 mb-2">
+              Category
+            </p>
+            <Button
+              variant="ghost"
+              onClick={() => setActiveCategory(null)}
+              className={`w-full justify-between text-xs px-2 py-1.5 h-auto rounded font-medium transition-colors ${
+                activeCategory === null
+                  ? 'bg-primary/10 text-primary'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-muted/40'
+              }`}
+            >
+              <span>All tools</span>
+              <span
+                className={`text-[10px] tabular-nums ${activeCategory === null ? 'text-primary' : 'text-muted-foreground/60'}`}
               >
-                <span className="text-left truncate">{cat}</span>
-                <span
-                  className={`text-[10px] tabular-nums shrink-0 ml-1 ${isActive ? 'text-primary' : 'text-muted-foreground/60'}`}
+                {WORKSHOP_TOOLS.length}
+              </span>
+            </Button>
+            {CATEGORIES.map((cat) => {
+              const count = WORKSHOP_TOOLS.filter((t) => t.category === cat).length
+              const isActive = activeCategory === cat
+              return (
+                <Button
+                  variant="ghost"
+                  key={cat}
+                  onClick={() => setActiveCategory(isActive ? null : cat)}
+                  className={`w-full justify-between text-xs px-2 py-1.5 h-auto rounded font-medium transition-colors ${
+                    isActive
+                      ? 'bg-primary/10 text-primary'
+                      : 'text-muted-foreground hover:text-foreground hover:bg-muted/40'
+                  }`}
                 >
-                  {count}
-                </span>
-              </Button>
-            )
-          })}
-        </aside>
+                  <span className="text-left truncate">{cat}</span>
+                  <span
+                    className={`text-[10px] tabular-nums shrink-0 ml-1 ${isActive ? 'text-primary' : 'text-muted-foreground/60'}`}
+                  >
+                    {count}
+                  </span>
+                </Button>
+              )
+            })}
+          </aside>
 
-        {/* ── Main content ── */}
-        <div className="flex-1 min-w-0 space-y-8">
-          {/* Persona-specific entry points */}
-          {selectedPersona === 'executive' && <ExecutiveBanner />}
-          {selectedPersona === 'curious' && <CuriousStartHere />}
+          {/* ── Main content ── */}
+          <div className="flex-1 min-w-0 space-y-8">
+            {/* Persona-specific entry points */}
+            {selectedPersona === 'executive' && <ExecutiveBanner />}
+            {selectedPersona === 'curious' && <CuriousStartHere />}
 
-          {/* Persona recommended banner (non-executive/curious) */}
-          {selectedPersona && selectedPersona !== 'executive' && selectedPersona !== 'curious' && (
-            <PersonaBanner
-              persona={selectedPersona}
-              recommendedCount={recommendedTools.length}
-              showingPersona={isPersonaFiltered}
-              onToggle={() => setShowPersonaFilter((v) => !v)}
-            />
-          )}
-
-          {/* Search + filter */}
-          <div className="space-y-3">
-            <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3">
-              <div className="relative flex-1 w-full sm:max-w-md">
-                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-                <Input
-                  placeholder="Search tools, algorithms, or keywords..."
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  className="pl-9"
+            {/* Persona recommended banner (non-executive/curious) */}
+            {selectedPersona &&
+              selectedPersona !== 'executive' &&
+              selectedPersona !== 'curious' && (
+                <PersonaBanner
+                  persona={selectedPersona}
+                  recommendedCount={recommendedTools.length}
+                  showingPersona={isPersonaFiltered}
+                  onToggle={() => setShowPersonaFilter((v) => !v)}
                 />
-              </div>
-              <div className="flex items-center gap-2">
-                <span className="text-sm text-muted-foreground">
-                  {filteredTools.length} tool{filteredTools.length !== 1 ? 's' : ''}
-                  {isPersonaFiltered && (
+              )}
+
+            {/* Search + filter */}
+            <div className="space-y-3">
+              <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3">
+                <div className="relative flex-1 w-full sm:max-w-md">
+                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+                  <Input
+                    placeholder="Search tools, algorithms, or keywords..."
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    className="pl-9"
+                  />
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-sm text-muted-foreground">
+                    {filteredTools.length} tool{filteredTools.length !== 1 ? 's' : ''}
+                    {isPersonaFiltered && (
+                      <Button
+                        variant="ghost"
+                        onClick={() => setShowPersonaFilter(false)}
+                        className="ml-2 text-xs text-primary hover:underline"
+                      >
+                        Show all
+                      </Button>
+                    )}
+                  </span>
+                  {myPlaygroundTools.length > 0 && (
                     <Button
                       variant="ghost"
-                      onClick={() => setShowPersonaFilter(false)}
-                      className="ml-2 text-xs text-primary hover:underline"
+                      onClick={() => setShowOnlyPlaygroundTools(!showOnlyPlaygroundTools)}
+                      className={`inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg border transition-colors font-medium whitespace-nowrap ${
+                        showOnlyPlaygroundTools
+                          ? 'border-primary bg-primary/10 text-primary'
+                          : 'border-border bg-muted/30 text-muted-foreground hover:text-foreground hover:border-primary/30'
+                      }`}
+                      aria-pressed={showOnlyPlaygroundTools}
                     >
-                      Show all
+                      <BookmarkCheck size={12} />
+                      My ({myPlaygroundTools.length})
                     </Button>
                   )}
-                </span>
-                {myPlaygroundTools.length > 0 && (
+                </div>
+              </div>
+
+              {/* Category filter pills — mobile/tablet only; desktop uses sidebar */}
+              <div className="flex flex-wrap gap-2 lg:hidden">
+                <Button
+                  variant="ghost"
+                  onClick={() => setActiveCategory(null)}
+                  className={`flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
+                    activeCategory === null
+                      ? 'bg-primary/10 text-primary border-primary/30'
+                      : 'text-muted-foreground border-border hover:text-foreground hover:border-border/60'
+                  }`}
+                >
+                  All
+                  <span
+                    className={`text-[10px] px-1 rounded ${activeCategory === null ? 'text-primary' : 'text-muted-foreground'}`}
+                  >
+                    {WORKSHOP_TOOLS.length}
+                  </span>
+                </Button>
+                {CATEGORIES.map((cat) => {
+                  const count = WORKSHOP_TOOLS.filter((t) => t.category === cat).length
+                  const isActive = activeCategory === cat
+                  return (
+                    <Button
+                      variant="ghost"
+                      key={cat}
+                      onClick={() => setActiveCategory(isActive ? null : cat)}
+                      className={`flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
+                        isActive
+                          ? 'bg-primary/10 text-primary border-primary/30'
+                          : 'text-muted-foreground border-border hover:text-foreground hover:border-border/60'
+                      }`}
+                    >
+                      {cat}
+                      <span
+                        className={`text-[10px] px-1 rounded ${isActive ? 'text-primary' : 'text-muted-foreground'}`}
+                      >
+                        {count}
+                      </span>
+                    </Button>
+                  )
+                })}
+                {!isEmbedded && (
                   <Button
                     variant="ghost"
-                    onClick={() => setShowOnlyPlaygroundTools(!showOnlyPlaygroundTools)}
-                    className={`inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg border transition-colors font-medium whitespace-nowrap ${
-                      showOnlyPlaygroundTools
-                        ? 'border-primary bg-primary/10 text-primary'
-                        : 'border-border bg-muted/30 text-muted-foreground hover:text-foreground hover:border-primary/30'
+                    onClick={() =>
+                      setWipFilter((v) => (v === 'all' ? 'only' : v === 'only' ? 'hide' : 'all'))
+                    }
+                    className={`flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
+                      wipFilter === 'only'
+                        ? 'bg-status-warning/15 text-status-warning border-status-warning/40'
+                        : wipFilter === 'hide'
+                          ? 'bg-muted text-muted-foreground border-border line-through'
+                          : 'text-muted-foreground border-border hover:text-foreground hover:border-border/60'
                     }`}
-                    aria-pressed={showOnlyPlaygroundTools}
+                    title={
+                      wipFilter === 'all'
+                        ? 'Click to show only WIP tools'
+                        : wipFilter === 'only'
+                          ? 'Click to hide WIP tools'
+                          : 'Click to show all tools'
+                    }
                   >
-                    <BookmarkCheck size={12} />
-                    My ({myPlaygroundTools.length})
+                    <Wrench className="w-3 h-3" aria-hidden="true" />
+                    {wipFilter === 'hide' ? 'WIP hidden' : 'WIP'}
+                    {wipFilter !== 'hide' && (
+                      <span
+                        className={`text-[10px] px-1 rounded ${wipFilter === 'only' ? 'text-status-warning' : 'text-muted-foreground'}`}
+                      >
+                        {WORKSHOP_TOOLS.filter((t) => t.wip).length}
+                      </span>
+                    )}
                   </Button>
                 )}
               </div>
             </div>
 
-            {/* Category filter pills — mobile/tablet only; desktop uses sidebar */}
-            <div className="flex flex-wrap gap-2 lg:hidden">
-              <Button
-                variant="ghost"
-                onClick={() => setActiveCategory(null)}
-                className={`flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
-                  activeCategory === null
-                    ? 'bg-primary/10 text-primary border-primary/30'
-                    : 'text-muted-foreground border-border hover:text-foreground hover:border-border/60'
-                }`}
-              >
-                All
-                <span
-                  className={`text-[10px] px-1 rounded ${activeCategory === null ? 'text-primary' : 'text-muted-foreground'}`}
-                >
-                  {WORKSHOP_TOOLS.length}
-                </span>
-              </Button>
-              {CATEGORIES.map((cat) => {
-                const count = WORKSHOP_TOOLS.filter((t) => t.category === cat).length
-                const isActive = activeCategory === cat
-                return (
-                  <Button
-                    variant="ghost"
-                    key={cat}
-                    onClick={() => setActiveCategory(isActive ? null : cat)}
-                    className={`flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
-                      isActive
-                        ? 'bg-primary/10 text-primary border-primary/30'
-                        : 'text-muted-foreground border-border hover:text-foreground hover:border-border/60'
-                    }`}
-                  >
-                    {cat}
-                    <span
-                      className={`text-[10px] px-1 rounded ${isActive ? 'text-primary' : 'text-muted-foreground'}`}
-                    >
-                      {count}
-                    </span>
-                  </Button>
-                )
-              })}
-              {!isEmbedded && (
-                <Button
-                  variant="ghost"
-                  onClick={() =>
-                    setWipFilter((v) => (v === 'all' ? 'only' : v === 'only' ? 'hide' : 'all'))
-                  }
-                  className={`flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
-                    wipFilter === 'only'
-                      ? 'bg-status-warning/15 text-status-warning border-status-warning/40'
-                      : wipFilter === 'hide'
-                        ? 'bg-muted text-muted-foreground border-border line-through'
-                        : 'text-muted-foreground border-border hover:text-foreground hover:border-border/60'
-                  }`}
-                  title={
-                    wipFilter === 'all'
-                      ? 'Click to show only WIP tools'
-                      : wipFilter === 'only'
-                        ? 'Click to hide WIP tools'
-                        : 'Click to show all tools'
-                  }
-                >
-                  <Wrench className="w-3 h-3" aria-hidden="true" />
-                  {wipFilter === 'hide' ? 'WIP hidden' : 'WIP'}
-                  {wipFilter !== 'hide' && (
-                    <span
-                      className={`text-[10px] px-1 rounded ${wipFilter === 'only' ? 'text-status-warning' : 'text-muted-foreground'}`}
-                    >
-                      {WORKSHOP_TOOLS.filter((t) => t.wip).length}
-                    </span>
-                  )}
-                </Button>
-              )}
-            </div>
-          </div>
-
-          {/* Hero cards — Playgrounds (hidden when category filter is active) */}
-          {!activeCategory && (
-            <div>
-              <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-3">
-                Playgrounds
-              </h3>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                <HeroCard
-                  to="/playground/interactive"
-                  icon={Play}
-                  title="Interactive Playground"
-                  description="Key generation, KEM & encryption, signing, hashing, symmetric operations — live via WebAssembly."
-                  badge="ML-KEM · ML-DSA · AES"
-                />
-                <HeroCard
-                  to="/playground/hsm"
-                  icon={Cpu}
-                  title="PKCS#11 HSM Playground"
-                  description="Real PKCS#11 v3.2 operations with SoftHSM WASM — dual C++/Rust engine cross-validation and ACVP."
-                />
+            {/* Hero cards — Playgrounds (hidden when category filter is active) */}
+            {!activeCategory && (
+              <div>
+                <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-3">
+                  Playgrounds
+                </h3>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                  <HeroCard
+                    to="/playground/interactive"
+                    icon={Play}
+                    title="Interactive Playground"
+                    description="Key generation, KEM & encryption, signing, hashing, symmetric operations — live via WebAssembly."
+                    badge="ML-KEM · ML-DSA · AES"
+                  />
+                  <HeroCard
+                    to="/playground/hsm"
+                    icon={Cpu}
+                    title="PKCS#11 HSM Playground"
+                    description="Real PKCS#11 v3.2 operations with SoftHSM WASM — dual C++/Rust engine cross-validation and ACVP."
+                  />
+                </div>
               </div>
-            </div>
-          )}
+            )}
 
-          {Object.keys(groupedTools).length === 0 && (
-            <EmptyState
-              icon={<Search className="w-6 h-6" />}
-              title={`No tools match \u201c${searchQuery}\u201d`}
-            />
-          )}
+            {Object.keys(groupedTools).length === 0 && (
+              <EmptyState
+                icon={<Search className="w-6 h-6" />}
+                title={`No tools match \u201c${searchQuery}\u201d`}
+              />
+            )}
 
-          {/* Tool grid by category */}
-          {CATEGORIES.map((category) => {
-            const tools = groupedTools[category]
-            if (!tools) return null
-            return (
-              <div key={category}>
-                <h4 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-3">
-                  {category}
-                </h4>
-                {category === 'Sandbox' && <SandboxAccessBanner />}
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-                  {tools.map((tool) => {
-                    const Icon = tool.icon
-                    const isBookmarked = myPlaygroundTools.includes(tool.id)
-                    return (
-                      <div key={tool.id} className="relative">
-                        <Link
-                          to={`/playground/${tool.id}`}
-                          onClick={() => logEvent('Playground', 'Tool Open', personaLabel(tool.id))}
-                          className="glass-panel p-4 h-auto text-left hover:border-primary/40 transition-colors cursor-pointer group items-start justify-start flex"
-                        >
-                          <div className="flex items-start gap-3 w-full">
-                            <Icon className="w-5 h-5 text-primary mt-0.5 shrink-0" />
-                            <div className="min-w-0 flex-1 pr-6">
-                              <div className="flex items-center gap-2 flex-wrap">
-                                <p className="font-medium text-foreground group-hover:text-primary transition-colors">
-                                  {tool.name}
+            {/* Tool grid by category */}
+            {CATEGORIES.map((category) => {
+              const tools = groupedTools[category]
+              if (!tools) return null
+              return (
+                <div key={category}>
+                  <h4 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-3">
+                    {category}
+                  </h4>
+                  {category === 'Sandbox' && <SandboxAccessBanner />}
+                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                    {tools.map((tool) => {
+                      const Icon = tool.icon
+                      const isBookmarked = myPlaygroundTools.includes(tool.id)
+                      return (
+                        <div key={tool.id} className="relative">
+                          <Link
+                            to={`/playground/${tool.id}`}
+                            onClick={() =>
+                              logEvent('Playground', 'Tool Open', personaLabel(tool.id))
+                            }
+                            className="glass-panel p-4 h-auto text-left hover:border-primary/40 transition-colors cursor-pointer group items-start justify-start flex"
+                          >
+                            <div className="flex items-start gap-3 w-full">
+                              <Icon className="w-5 h-5 text-primary mt-0.5 shrink-0" />
+                              <div className="min-w-0 flex-1 pr-6">
+                                <div className="flex items-center gap-2 flex-wrap">
+                                  <p className="font-medium text-foreground group-hover:text-primary transition-colors">
+                                    {tool.name}
+                                  </p>
+                                  <DifficultyBadge level={tool.difficulty} />
+                                  {tool.wip && <WipBadge />}
+                                </div>
+                                <p className="text-sm text-muted-foreground mt-1 line-clamp-2">
+                                  {(selectedPersona === 'curious' &&
+                                    getCuriousToolDescription(tool.id)) ||
+                                    tool.description}
                                 </p>
-                                <DifficultyBadge level={tool.difficulty} />
-                                {tool.wip && <WipBadge />}
-                              </div>
-                              <p className="text-sm text-muted-foreground mt-1 line-clamp-2">
-                                {(selectedPersona === 'curious' &&
-                                  getCuriousToolDescription(tool.id)) ||
-                                  tool.description}
-                              </p>
-                              <div className="flex flex-wrap gap-1 mt-2">
-                                {tool.algorithms.map((algo) => (
-                                  <span
-                                    key={algo}
-                                    className="inline-block text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground"
-                                  >
-                                    {algo}
-                                  </span>
-                                ))}
-                              </div>
-                              {/* div wraps the badge to intercept clicks (the badge itself is the focusable target).
+                                <div className="flex flex-wrap gap-1 mt-2">
+                                  {tool.algorithms.map((algo) => (
+                                    <span
+                                      key={algo}
+                                      className="inline-block text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground"
+                                    >
+                                      {algo}
+                                    </span>
+                                  ))}
+                                </div>
+                                {/* div wraps the badge to intercept clicks (the badge itself is the focusable target).
                                   Same pattern as ModuleCard; the inner Badge handles its own keyboard interaction. */}
-                              {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
-                              <div
-                                onClick={(e) => {
-                                  e.preventDefault()
-                                  e.stopPropagation()
-                                  navigate(
-                                    `/revisions?domain=tool&entity=${encodeURIComponent(tool.pt_id)}`
-                                  )
-                                }}
-                              >
-                                <ReviewedBadge
-                                  domain="tool"
-                                  entityId={tool.pt_id}
-                                  className="mt-2"
-                                  onOpenDrilldown={() =>
+                                {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+                                <div
+                                  onClick={(e) => {
+                                    e.preventDefault()
+                                    e.stopPropagation()
                                     navigate(
                                       `/revisions?domain=tool&entity=${encodeURIComponent(tool.pt_id)}`
                                     )
-                                  }
-                                />
-                              </div>
-                              {tool.opensourceTool && (
-                                <div className="mt-2 flex items-center gap-1 text-xs text-muted-foreground">
-                                  <ExternalLink className="w-3 h-3 shrink-0" aria-hidden="true" />
-                                  <span className="truncate">{tool.opensourceTool.name}</span>
+                                  }}
+                                >
+                                  <ReviewedBadge
+                                    domain="tool"
+                                    entityId={tool.pt_id}
+                                    className="mt-2"
+                                    onOpenDrilldown={() =>
+                                      navigate(
+                                        `/revisions?domain=tool&entity=${encodeURIComponent(tool.pt_id)}`
+                                      )
+                                    }
+                                  />
                                 </div>
-                              )}
+                                {tool.opensourceTool && (
+                                  <div className="mt-2 flex items-center gap-1 text-xs text-muted-foreground">
+                                    <ExternalLink className="w-3 h-3 shrink-0" aria-hidden="true" />
+                                    <span className="truncate">{tool.opensourceTool.name}</span>
+                                  </div>
+                                )}
+                              </div>
                             </div>
-                          </div>
-                        </Link>
-                        <Button
-                          variant="ghost"
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            toggleMyPlaygroundTool(tool.id)
-                          }}
-                          className={`absolute top-2 right-2 p-1 rounded transition-colors ${
-                            isBookmarked
-                              ? 'text-primary hover:text-primary/80'
-                              : 'text-muted-foreground/40 hover:text-primary'
-                          }`}
-                          aria-label={isBookmarked ? 'Remove from My Tools' : 'Add to My Tools'}
-                        >
-                          {isBookmarked ? <BookmarkCheck size={14} /> : <Bookmark size={14} />}
-                        </Button>
-                      </div>
-                    )
-                  })}
+                          </Link>
+                          <Button
+                            variant="ghost"
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              toggleMyPlaygroundTool(tool.id)
+                            }}
+                            className={`absolute top-2 right-2 p-1 rounded transition-colors ${
+                              isBookmarked
+                                ? 'text-primary hover:text-primary/80'
+                                : 'text-muted-foreground/40 hover:text-primary'
+                            }`}
+                            aria-label={isBookmarked ? 'Remove from My Tools' : 'Add to My Tools'}
+                          >
+                            {isBookmarked ? <BookmarkCheck size={14} /> : <Bookmark size={14} />}
+                          </Button>
+                        </div>
+                      )
+                    })}
+                  </div>
                 </div>
-              </div>
-            )
-          })}
+              )
+            })}
+          </div>
+          {/* end main content */}
         </div>
-        {/* end main content */}
-      </div>
+      )}
       {/* end two-column flex */}
     </div>
   )

--- a/src/components/Threats/ThreatsDashboard.tsx
+++ b/src/components/Threats/ThreatsDashboard.tsx
@@ -21,10 +21,15 @@ import {
   useTrustTierFilter,
   matchesTrustTierFilter,
 } from '../common/TrustTierFilter'
-import { logEvent } from '../../utils/analytics'
+import { logEvent, personaLabel } from '../../utils/analytics'
 import { usePersonaStore } from '../../store/usePersonaStore'
 import { useBookmarkStore } from '../../store/useBookmarkStore'
-import { INDUSTRY_TO_THREATS_MAP } from '../../data/personaConfig'
+import {
+  INDUSTRY_TO_THREATS_MAP,
+  PERSONA_THREATS_DEFAULT_INDUSTRIES,
+} from '../../data/personaConfig'
+import { PersonaDefaultsBanner } from '../common/PersonaDefaultsBanner'
+import { usePersonaDefaults } from '@/hooks/usePersonaDefaults'
 import clsx from 'clsx'
 import { PageHeader } from '../common/PageHeader'
 import { buildEndorsementUrl, buildFlagUrl } from '@/utils/endorsement'
@@ -238,12 +243,36 @@ export const ThreatsDashboard: React.FC = () => {
     [semantic.mode, semantic.hits]
   )
 
+  // Persona-aware default industries — applies when the user has a persona
+  // set but no explicit industry picked, and hasn't opted out via ?prefs=off.
+  // The persona's PERSONA_THREATS_DEFAULT_INDUSTRIES list (e.g. executive →
+  // ['Finance & Banking', 'Government & Defense']) is mapped through
+  // INDUSTRY_TO_THREATS_MAP to threat-industry strings, which then act as
+  // a filter on the threats corpus. Researcher + curious have empty default
+  // sets → no narrowing.
+  const personaDefaults = usePersonaDefaults()
+  const personaDefaultThreatIndustries = useMemo<string[]>(() => {
+    if (personaDefaults.prefsOff) return []
+    if (!selectedPersona) return []
+    if (selectedIndustries.length > 0) return []
+    if (storeIndustries.length > 0) return []
+    const personaIndustryKeys = PERSONA_THREATS_DEFAULT_INDUSTRIES[selectedPersona] ?? [] // eslint-disable-line security/detect-object-injection
+    return personaIndustryKeys
+      .flatMap((key) => INDUSTRY_TO_THREATS_MAP[key] ?? []) // eslint-disable-line security/detect-object-injection
+      .filter((ind) => threatsData.some((d) => d.industry === ind))
+  }, [selectedPersona, selectedIndustries, storeIndustries, personaDefaults.prefsOff])
+  const personaDefaultActive = personaDefaultThreatIndustries.length > 0
+
   const filteredAndSortedData = useMemo(() => {
     let data = [...threatsData]
 
     // Filter by Industry (multi-select: empty = all)
     if (selectedIndustries.length > 0) {
       data = data.filter((item) => selectedIndustries.includes(item.industry))
+    } else if (personaDefaultActive) {
+      // Persona-default narrowing — applies only when no explicit industry is
+      // picked (above branch) and the user hasn't opted out via ?prefs=off.
+      data = data.filter((item) => personaDefaultThreatIndustries.includes(item.industry))
     }
 
     // Filter by Criticality
@@ -327,6 +356,8 @@ export const ThreatsDashboard: React.FC = () => {
     showOnlyThreats,
     myThreats,
     tierFilter,
+    personaDefaultActive,
+    personaDefaultThreatIndustries,
   ])
 
   // When a persona is set but no explicit industry filter is active, compute the persona's
@@ -402,6 +433,23 @@ export const ThreatsDashboard: React.FC = () => {
         <div className="glass-panel p-3 mb-4 flex items-center gap-2 text-sm text-muted-foreground">
           <Info size={14} className="text-primary flex-shrink-0" />
           <span>{personaSummary}</span>
+        </div>
+      )}
+
+      {/* Persona-aware default-filter banner — appears when persona has
+          a default-industries set, the user hasn't picked an explicit
+          industry, and hasn't opted out via ?prefs=off. */}
+      {personaDefaultActive && (
+        <div className="mb-4">
+          <PersonaDefaultsBanner
+            matchedCount={filteredAndSortedData.length}
+            totalCount={threatsData.length}
+            noun="threat"
+            onReset={() => {
+              personaDefaults.resetToFullSet()
+              logEvent('Threats', 'Persona Prefs Off', personaLabel())
+            }}
+          />
         </div>
       )}
 

--- a/src/components/Timeline/TimelineView.tsx
+++ b/src/components/Timeline/TimelineView.tsx
@@ -7,7 +7,7 @@ import { timelineData, timelineMetadata, transformToGanttData } from '../../data
 import type { GanttCountryData } from '../../types/timeline'
 import { FilterChip } from '../common/FilterChip'
 import { usePersonaStore } from '../../store/usePersonaStore'
-import { REGION_COUNTRIES_MAP } from '../../data/personaConfig'
+import { REGION_COUNTRIES_MAP, PERSONA_TIMELINE_REGION } from '../../data/personaConfig'
 import { COUNTRY_ALIASES } from '../../data/countryAliases'
 import { SimpleGanttChart } from './SimpleGanttChart'
 import { LeftNavTOC } from '@/components/common/LeftNavTOC'
@@ -85,11 +85,32 @@ export const TimelineView = () => {
 
   const [searchParams, setSearchParams] = useSearchParams()
 
-  // Region filter — preset from URL ?region= or persona preference
+  // Region filter — preset from (in order):
+  //   1. URL `?region=` deep-link
+  //   2. URL `?country=` deep-link → 'All' (country wins)
+  //   3. URL `?prefs=off` → 'All' (user explicitly opted out)
+  //   4. usePersonaStore.selectedRegion (user's stored region)
+  // The persona-default fallback (PERSONA_TIMELINE_REGION[persona]) lives in
+  // a useEffect below — Zustand's persist middleware may not have rehydrated
+  // the persona by the time this useState initialiser runs, so reading
+  // selectedPersona here is unreliable on first paint.
   const [regionFilter, setRegionFilter] = useState<string>(() => {
-    if (searchParams.get('country')) return 'All' // country deep-link → don't preset region
-    return searchParams.get('region') ?? usePersonaStore.getState().selectedRegion ?? 'All'
+    if (searchParams.get('country')) return 'All'
+    const urlRegion = searchParams.get('region')
+    if (urlRegion) return urlRegion
+    if (searchParams.get('prefs') === 'off') return 'All'
+    const storeRegion = usePersonaStore.getState().selectedRegion
+    if (storeRegion) return storeRegion
+    return 'All'
   })
+
+  // Persona-default region is applied inside the URL-sync useEffect below
+  // (the one keyed on `searchParams`). That effect already runs whenever
+  // searchParams changes — including on the rehydration re-render — so
+  // folding the persona-default into its logic keeps a single source of
+  // truth for the region value and avoids the two-effect race that
+  // otherwise overwrites the persona default on every re-render.
+  const storeSelectedRegion = usePersonaStore((s) => s.selectedRegion)
 
   // Country filter — preset from URL ?country= param if present (with alias resolution)
   const initialCountryParam = searchParams.get('country')
@@ -178,7 +199,21 @@ export const TimelineView = () => {
     const known = timelineData?.map((d) => d.countryName) ?? []
     const paramCountry = searchParams.get('country')
     const { resolved: nextCountry, wasUnknown } = resolveCountryParam(paramCountry, known)
-    const nextRegion = searchParams.get('region') ?? 'All'
+    // nextRegion precedence (persona-overwhelm rollout):
+    //   1. ?region= URL deep-link
+    //   2. ?country= deep-link → 'All' (country wins)
+    //   3. ?prefs=off → 'All' (user opted out of persona default)
+    //   4. usePersonaStore.selectedRegion (user's stored region)
+    //   5. PERSONA_TIMELINE_REGION[persona] (NEW)
+    //   6. 'All'
+    let nextRegion = searchParams.get('region') ?? 'All'
+    if (!searchParams.get('region') && !paramCountry && searchParams.get('prefs') !== 'off') {
+      if (storeSelectedRegion) nextRegion = storeSelectedRegion
+      else if (selectedPersona) {
+        const personaDefault = PERSONA_TIMELINE_REGION[selectedPersona] // eslint-disable-line security/detect-object-injection
+        if (personaDefault) nextRegion = personaDefault
+      }
+    }
     const nextQ = searchParams.get('q') ?? ''
 
     setCountryFilter((prev) => (prev !== nextCountry ? nextCountry : prev))
@@ -190,7 +225,8 @@ export const TimelineView = () => {
         duration: 4000,
       })
     }
-  }, [searchParams])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams, selectedPersona, storeSelectedRegion])
 
   const tierFilter = useTrustTierFilter()
 

--- a/src/components/common/PersonaDefaultsBanner.tsx
+++ b/src/components/common/PersonaDefaultsBanner.tsx
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/**
+ * PersonaDefaultsBanner — the matched/show-all banner used across pages
+ * that apply persona-aware default filters (Library, Migrate, Threats,
+ * Timeline, etc.).
+ *
+ * Renders the canonical sentence:
+ *   "Showing N {noun} matched to your role · See all M"
+ *
+ * Render only when persona narrowing is currently active (i.e. the user
+ * has a persona set with a preferred subset, has not picked an explicit
+ * filter, and has not opted out via `?prefs=off`). Each call site is
+ * responsible for that conditional — the banner itself is presentational.
+ *
+ * Pair with `usePersonaDefaults()` from `@/hooks/usePersonaDefaults` for
+ * the `?prefs=off` URL state and the persona-change reset.
+ */
+import { Button } from '@/components/ui/button'
+
+export interface PersonaDefaultsBannerProps {
+  matchedCount: number
+  totalCount: number
+  /** Singular noun for the items being filtered (e.g. "document",
+   *  "product", "threat", "country"). The banner handles pluralization. */
+  noun: string
+  /** Callback to reset to the full set. Use the `resetToFullSet`
+   *  return from `usePersonaDefaults()`. */
+  onReset: () => void
+  /** Optional className to extend the wrapper styles. */
+  className?: string
+}
+
+export function PersonaDefaultsBanner({
+  matchedCount,
+  totalCount,
+  noun,
+  onReset,
+  className = '',
+}: PersonaDefaultsBannerProps) {
+  const pluralizedNoun = matchedCount !== 1 ? `${noun}s` : noun
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={`glass-panel inline-flex flex-wrap items-center gap-2 px-3 py-1.5 rounded-md text-xs ${className}`.trim()}
+    >
+      <span className="text-muted-foreground">
+        Showing {matchedCount} {pluralizedNoun} matched to your role
+      </span>
+      <span className="text-muted-foreground/60">·</span>
+      <Button variant="link" onClick={onReset} className="text-xs h-auto p-0">
+        See all {totalCount}
+      </Button>
+    </div>
+  )
+}

--- a/src/data/personaConfig.ts
+++ b/src/data/personaConfig.ts
@@ -43,6 +43,7 @@ export const PERSONA_NAV_PATHS: Record<PersonaId, string[] | null> = {
     '/algorithms',
     '/library',
     '/playground',
+    '/openssl',
     '/leaders',
     '/patents',
     '/revisions',
@@ -71,7 +72,6 @@ export const PERSONA_NAV_PATHS: Record<PersonaId, string[] | null> = {
     '/migrate',
     '/playground',
     '/patents',
-    '/openssl',
     '/revisions',
   ],
 }

--- a/src/data/personaConfig.ts
+++ b/src/data/personaConfig.ts
@@ -225,6 +225,30 @@ export const REGION_COUNTRY_MAP: Record<Region, string | null> = {
  * Broad region → all matching country names in the timeline CSV data.
  * Used to power multi-country region filter in the Gantt chart.
  */
+/**
+ * Per-persona default region for /timeline when the user has no
+ * `selectedRegion` in the persona store and no `?region=` URL param.
+ *
+ * Per the persona-overwhelm audit (2026-05-22): every persona was landing
+ * on the same 40-country × ~225-event chart regardless of role. This map
+ * provides a sensible default region per persona so the Gantt chart is
+ * useful on first paint.
+ *
+ * Researcher = 'All' — the page is a research instrument for them.
+ * Other personas get a single region matched to their primary regulator
+ * or operating geography. Users can switch regions in the dropdown or
+ * opt out of the persona default via the "See all" reset link
+ * (which writes ?prefs=off).
+ */
+export const PERSONA_TIMELINE_REGION: Record<PersonaId, Region | 'All'> = {
+  executive: 'americas',
+  developer: 'americas',
+  architect: 'global',
+  researcher: 'All',
+  ops: 'americas',
+  curious: 'americas',
+}
+
 export const REGION_COUNTRIES_MAP: Record<Region, string[]> = {
   americas: ['United States', 'Canada'],
   eu: ['European Union', 'France', 'Germany', 'Italy', 'Spain', 'United Kingdom', 'Czech Republic'],

--- a/src/data/personaConfig.ts
+++ b/src/data/personaConfig.ts
@@ -419,6 +419,32 @@ export const INDUSTRY_SLUG_TO_LABEL: Record<string, string> = {
   retail: 'Retail & E-Commerce',
 }
 
+/**
+ * Per-persona default industries for /threats when no industry is picked.
+ *
+ * The persona-overwhelm audit (2026-05-22) flagged that /threats renders
+ * the full unfiltered corpus when the user has a persona set but no
+ * industry — the only page on the site where persona alone doesn't
+ * pre-shape the view. This map provides a sensible default industry set
+ * per persona so the page is useful on first paint.
+ *
+ * Each value is an array of INDUSTRY_TO_THREATS_MAP keys; the resolver
+ * in `ThreatsDashboard` then maps these through INDUSTRY_TO_THREATS_MAP
+ * to actual threat-industry strings.
+ *
+ * Researcher + curious are intentionally empty: researcher wants the
+ * full corpus; curious gets a plain-language narrative card instead
+ * (see `personaSummary` in ThreatsDashboard).
+ */
+export const PERSONA_THREATS_DEFAULT_INDUSTRIES: Record<PersonaId, string[]> = {
+  executive: ['Finance & Banking', 'Government & Defense'],
+  developer: ['Technology'],
+  architect: ['Technology', 'Telecommunications'],
+  researcher: [],
+  ops: ['Energy & Utilities', 'Telecommunications'],
+  curious: [],
+}
+
 export const INDUSTRY_TO_THREATS_MAP: Record<string, string[]> = {
   'Finance & Banking': [
     'Financial Services / Banking',

--- a/src/hooks/usePersonaDefaults.ts
+++ b/src/hooks/usePersonaDefaults.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/**
+ * usePersonaDefaults — URL-state primitives for the "persona-aware default
+ * filter" pattern used across /library, /migrate, /threats, /timeline,
+ * /assess, and /playground.
+ *
+ * Three concerns this hook handles:
+ *
+ *   1. Reading whether the user has opted out of persona defaults via the
+ *      `?prefs=off` URL param. Pages combine this with their own preferred-
+ *      set logic (e.g. PERSONA_LIBRARY_CATEGORIES, PERSONA_MIGRATE_LAYERS)
+ *      to decide if persona narrowing is currently active.
+ *
+ *   2. Providing a `resetToFullSet()` callback that writes `?prefs=off`
+ *      into the URL so the opt-out is shareable / bookmarkable.
+ *
+ *   3. Auto-stripping `?prefs=off` when the persona changes — switching
+ *      persona means asking for a new set of defaults, so a lingering
+ *      opt-out is no longer the user's intent.
+ *
+ * See `<PersonaDefaultsBanner>` for the matching UI surface.
+ */
+import { useCallback, useEffect } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { usePersonaStore } from '@/store/usePersonaStore'
+
+export interface UsePersonaDefaultsResult {
+  /** True when the user has opted out of persona defaults via `?prefs=off`.
+   *  Pages should treat persona narrowing as inactive when this is true. */
+  prefsOff: boolean
+  /** Write `?prefs=off` into the URL. Use as the onClick for the
+   *  "See all N" reset link in `<PersonaDefaultsBanner>`. */
+  resetToFullSet: () => void
+  /** Strip `?prefs=off` from the URL. Called internally when persona
+   *  changes; exposed for pages that need to clear it explicitly. */
+  reapplyDefaults: () => void
+}
+
+export function usePersonaDefaults(): UsePersonaDefaultsResult {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const selectedPersona = usePersonaStore((s) => s.selectedPersona)
+  const prefsOff = searchParams.get('prefs') === 'off'
+
+  const resetToFullSet = useCallback(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev)
+        next.set('prefs', 'off')
+        return next
+      },
+      { replace: true }
+    )
+  }, [setSearchParams])
+
+  const reapplyDefaults = useCallback(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev)
+        next.delete('prefs')
+        return next
+      },
+      { replace: true }
+    )
+  }, [setSearchParams])
+
+  // On persona change, strip a lingering `?prefs=off` so the new persona's
+  // defaults apply. The user just told us their role changed; the prior
+  // opt-out is stale.
+  useEffect(() => {
+    if (prefsOff) {
+      reapplyDefaults()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedPersona])
+
+  return { prefsOff, resetToFullSet, reapplyDefaults }
+}

--- a/src/store/useAssessmentFormStore.ts
+++ b/src/store/useAssessmentFormStore.ts
@@ -51,7 +51,7 @@ export interface AssessmentFormState {
 
   // Actions
   setStep: (step: number) => void
-  setAssessmentMode: (mode: AssessmentMode) => void
+  setAssessmentMode: (mode: AssessmentMode | null) => void
   setIndustry: (industry: string) => void
   setCountry: (country: string) => void
   toggleCrypto: (algo: string) => void


### PR DESCRIPTION
## Summary

Completes the persona-overwhelm initiative across the 5 remaining pages. Each page now applies the user's persona signal (captured on Landing) to the first paint — reducing decision fatigue on /migrate, /assess, /playground, /threats, /timeline. Also folds repeated UX into a single shared scaffold (`<PersonaDefaultsBanner>` + `usePersonaDefaults()`) used across these pages and the existing /library.

Same pattern as the merged PRs for Library (#245) and Compliance (#250).

## Commits (8)

| # | Commit | Page |
|---|---|---|
| 1 | `33671888` | fix(persona-config): correct /openssl nav-path for architect+curious |
| 2 | `9d8a4b28` | feat(common): extract PersonaDefaultsBanner + usePersonaDefaults hook (refactors LibraryView to consume) |
| 3 | `972dcc49` | feat(migrate): apply PERSONA_MIGRATE_LAYERS as default filter |
| 4 | `b7e50a8d` | feat(assess): auto-skip ModeSelector when persona resolves recommended mode |
| 5 | `50d9868f` | feat(playground): gate full grid behind disclosure for curious + ?prefs=off |
| 6 | `295a617f` | feat(threats): persona-only default industries + reset banner |
| 7 | `2921341e` | feat(timeline): per-persona default region (PERSONA_TIMELINE_REGION) |
| 8 | `c875b5b0` | docs(changelog): persona-overwhelm rollout |

## What changes for the user

| Page | Today | After |
|---|---|---|
| `/migrate` | Every persona sees 832 products | Executive: ~134 (Cloud + AppServers). Developer / architect / ops: their layer subset. Researcher / curious: unchanged 832. |
| `/assess` | Every persona must click Quick or Comprehensive | Executive + curious land in Quick directly. Developer / architect / researcher / ops land in Comprehensive directly. "Switch mode" link always visible. |
| `/playground` | Curious lands on a 35-tool grid with raw byte panes | Curious lands on `CuriousStartHere` only; "Show full catalog (35 tools)" reveals the grid. Other personas unchanged. |
| `/threats` | Persona alone doesn't filter; user must pick an industry on Landing | Executive (no industry) → 8–12 Finance + Gov threats. Developer → Technology. Architect → Tech + Telecom. Ops → Energy + Telecom. Researcher / curious: full corpus. |
| `/timeline` | Every persona sees 40 countries | Developer / executive / ops / curious → Americas. Architect → Global. Researcher → All. URL `?region=` deep-link still wins. |
| `/openssl` (nav) | In curious nav (wrong — sends curious users to a CLI). Absent from architect (wrong). | In architect nav. Out of curious nav. |

Every page that narrows by default also gets a "Showing N matched to your role · See all M" banner with a one-click `?prefs=off` reset. Persona-change strips `prefs=off` so the new persona's defaults apply.

## Shared scaffolding

- `src/components/common/PersonaDefaultsBanner.tsx` — presentational banner.
- `src/hooks/usePersonaDefaults.ts` — `?prefs=off` URL state + persona-change reset.
- LibraryView refactored to consume them (net −27 LOC) — proves the API works without behavior change. 65 existing Library tests pass unchanged.

## Deferred (follow-up PRs)

- **Timeline `EventTypeFilter`** (Mandate / Standard / Guidance / Industry). Audit asked for it; requires either a new CSV `category` column or a string-inference classifier. Held for separate PR.
- **Leaders curated top-15** for curious. Editorial work — list TBD with you.
- Various secondary items per page (compare routes, ACVP export, lifecycle pill rows for Migrate, etc.) — flagged in audit MD impl-status sections.

Two pages remain entirely untouched by the persona-overwhelm initiative: `/leaders` and `/timeline EventTypeFilter`. All other audit pages from the 2026-05-22 batch are now closed or substantively shipped.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run format:check` — clean
- [x] `npm run lint` — 0 errors (1298 pre-existing warnings)
- [x] `npm run audit:matrix-refs` — PASS, 20 rows
- [x] `CI=1 npx vitest run` (full suite) — **3421 tests pass**, 0 failed, 17 skipped (maintainer-local)
- [x] `npx playwright test --project=chromium` (5 new specs) — **12/12 pass** in 32.1s
- [ ] CI green

Each commit was validated individually against tsc + targeted unit tests + its E2E before being added to the branch. The full pipeline above was run locally on the final branch tip before push.

## Files

23 files changed:

- **New (10)**: 5 E2E specs, 2 shared scaffold files (`PersonaDefaultsBanner` + `usePersonaDefaults`), 3 audit-doc updates ... see commits.
- **Modified**: `personaConfig.ts` (+50 — 2 new constants), 5 view files (Migrate / Assess / Playground / Threats / Timeline), `LibraryView.tsx` (refactor to consume shared scaffold), `useAssessmentFormStore.ts` (1-line type widening), `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)