### PR TITLE
feat(playground): SSH KEX + host-key variant selection

### DIFF
--- a/src/data/pqcProtocolMatrix.ts
+++ b/src/data/pqcProtocolMatrix.ts
@@ -509,6 +509,10 @@ export const PROTOCOL_MATRIX: ProtocolMatrixRow[] = [
         },
       },
     ],
+    gaps: [
+      'sntrup761x25519 (RFC 9941) not exposed — softhsmv3 has no sntrup KEM.',
+      'Composite SSH host-key signature (classical + ML-DSA) not supported in the tool — no IETF spec.',
+    ],
     liveDeployments: [
       {
         provider: 'OpenSSH',


### PR DESCRIPTION
## Summary

- Refactors `SshEngine` to accept a structured `SshHandshakeConfig` pairing any of 8 KEX algorithms (classical / 4 hybrid ML-KEM × {X25519,P-256} / 2 pure ML-KEM) with any of 4 host-key signature variants (Ed25519 + ML-DSA-{44,65,87})
- PQC runner now parametrises ML-KEM and ML-DSA parameter sets; skips classical EC keypair when pure ML-KEM is selected (CNSA 2.0 end-state)
- Legacy `'classical' | 'pqc'` strings preserved via back-compat shim — existing callers unchanged
- SSH playground panel exposes two chip selectors; classical baseline always runs alongside PQC config for size/timing comparisons
- Updates `pqcProtocolMatrix.ts` SSH row: pureKem/hybridKem/pureSig now full; remaining gaps (sntrup761x25519, composite host keys) documented

## Test plan

- [ ] SSH playground — verify KEX and host-key chip selectors render and produce comparison output
- [ ] Classical baseline still runs alongside selected PQC config
- [ ] Existing callers (`LiveSshHandshakeRunner`, unit tests) pass without changes
- [ ] `tsc --noEmit` clean, `eslint` clean, `npm run build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)