### PR TITLE
fix(learn): network-security step 6 + module auto-complete + PKCS#11 mech table (Track A)

### DIFF
--- a/src/components/PKILearning/moduleData.ts
+++ b/src/components/PKILearning/moduleData.ts
@@ -585,7 +585,7 @@ export const MODULE_STEP_COUNTS: Record<string, number> = {
   'confidential-computing': 5,
   'database-encryption-pqc': 5,
   'secrets-management-pqc': 5,
-  'network-security-pqc': 5,
+  'network-security-pqc': 6,
   'pqc-testing-validation': 7,
   'iam-pqc': 5,
   'energy-utilities-pqc': 5,
@@ -1370,6 +1370,7 @@ export const WORKSHOP_STEPS: Record<string, { id: string; label: string }[]> = {
     { id: 'ids-signature-updater', label: 'IDS Signature Updater' },
     { id: 'vendor-migration-matrix', label: 'Vendor Migration Matrix' },
     { id: 'ztna-pqc-designer', label: 'ZTNA PQC Designer' },
+    { id: 'network-telemetry-analyzer', label: 'Network Telemetry Analyzer' },
   ],
   'pqc-testing-validation': [
     { id: 'passive-discovery-lab', label: 'Passive Crypto Discovery Lab' },

--- a/src/store/useModuleStore.ts
+++ b/src/store/useModuleStore.ts
@@ -9,7 +9,7 @@ import {
   logStepComplete,
   logArtifactGenerated,
 } from '../utils/analytics'
-import { LEARN_SECTIONS } from '../components/PKILearning/moduleData'
+import { LEARN_SECTIONS, WORKSHOP_STEPS } from '../components/PKILearning/moduleData'
 
 const MODULE_STORE_VERSION = 14
 const KPI_HISTORY_CAP = 30
@@ -124,12 +124,26 @@ export const useModuleStore = create<ModuleState>()(
           const module = state.modules[moduleId]
           if (module && !module.completedSteps.includes(stepId)) {
             logStepComplete(moduleId, module.completedSteps.length, workshopStep)
+            const completedSteps = [...module.completedSteps, stepId]
+            // Auto-flip status to 'completed' when every registered workshop step
+            // for this module has been marked. The set membership check guards
+            // against unrelated step ids (e.g. learn-tab ids that share this action).
+            const workshopStepIds = WORKSHOP_STEPS[moduleId]?.map((s) => s.id) ?? []
+            const allWorkshopDone =
+              workshopStepIds.length > 0 &&
+              workshopStepIds.every((id) => completedSteps.includes(id))
+            const nextStatus =
+              allWorkshopDone && module.status !== 'completed' ? 'completed' : module.status
+            if (allWorkshopDone && module.status !== 'completed') {
+              logModuleComplete(moduleId)
+            }
             return {
               modules: {
                 ...state.modules,
                 [moduleId]: {
                   ...module,
-                  completedSteps: [...module.completedSteps, stepId],
+                  completedSteps,
+                  status: nextStatus,
                 },
               },
               timestamp: Date.now(),

--- a/src/wasm/pkcs11Inspect.ts
+++ b/src/wasm/pkcs11Inspect.ts
@@ -260,7 +260,15 @@ const CKM_TABLE: Record<number, ConstEntry> = {
     name: 'CKM_EC_EDWARDS_KEY_PAIR_GEN',
     description: 'Ed25519/Ed448 key pair generation',
   },
+  0x00001056: {
+    name: 'CKM_EC_MONTGOMERY_KEY_PAIR_GEN',
+    description: 'Montgomery curve key pair generation (X25519/X448)',
+  },
   0x00001057: { name: 'CKM_EDDSA', description: 'EdDSA signature (Ed25519/Ed448)' },
+  0x80001057: {
+    name: 'CKM_EDDSA_PH',
+    description: 'EdDSA pre-hashed signature (Ed25519ph/Ed448ph) [VENDOR]',
+  },
   // AES (§2.14)
   0x00001080: { name: 'CKM_AES_KEY_GEN', description: 'AES key generation' },
   0x00001081: { name: 'CKM_AES_ECB', description: 'AES-ECB (no padding)' },
@@ -269,8 +277,15 @@ const CKM_TABLE: Record<number, ConstEntry> = {
   0x00001087: { name: 'CKM_AES_GCM', description: 'AES-GCM authenticated encryption' },
   0x0000108a: { name: 'CKM_AES_CMAC', description: 'AES-CMAC (NIST SP 800-38B)' },
   0x00002109: { name: 'CKM_AES_KEY_WRAP', description: 'AES Key Wrap (RFC 3394)' },
+  0x0000210a: {
+    name: 'CKM_AES_KEY_WRAP_KWP',
+    description: 'AES Key Wrap with Padding (NIST SP 800-38F §6.3)',
+  },
   // HKDF (§2.43)
   0x0000402a: { name: 'CKM_HKDF_DERIVE', description: 'HKDF key derivation (RFC 5869)' },
+  // KMAC (§2.x) — PKCS#11 v3.2 / vendor codes
+  0x80000100: { name: 'CKM_KMAC_128', description: 'KMAC128 (NIST SP 800-185) [VENDOR]' },
+  0x80000101: { name: 'CKM_KMAC_256', description: 'KMAC256 (NIST SP 800-185) [VENDOR]' },
   // AEAD and Stateful Signatures
   0x00001225: { name: 'CKM_CHACHA20_KEY_GEN', description: 'ChaCha20 key generation' },
   0x00004021: { name: 'CKM_CHACHA20_POLY1305', description: 'ChaCha20-Poly1305 AEAD' },


### PR DESCRIPTION
## Summary

Bundled bug fixes from the 2026-06-01 remediation plan, **Track A** (quick / low-risk).

- **#9 — Network Security PQC workshop step 6 crash** (P0; the workshop is broken today): WORKSHOP_STEPS was missing the 6th entry, so WorkshopStepper read \`.label\` on \`undefined\` when the user clicked through.
- **#6 + #7 — Module status never set to 'completed'**: 20 modules across the Learn catalog share the same "Complete Module ✓" pattern with no \`updateModuleProgress({ status: 'completed' })\` call. Fixed centrally in \`useModuleStore.markStepComplete\` so it auto-flips status when every step in \`WORKSHOP_STEPS[moduleId]\` is in \`completedSteps\`. One change, 20 modules fixed, no per-component edits.
- **#1 — PKCS#11 mechanism inspector**: added 5 missing entries to \`CKM_TABLE\` (\`CKM_EC_MONTGOMERY_KEY_PAIR_GEN\`, \`CKM_EDDSA_PH\`, \`CKM_AES_KEY_WRAP_KWP\`, \`CKM_KMAC_128\`, \`CKM_KMAC_256\`) — verified against the softhsm wrapper's exported constants in \`src/wasm/softhsm.ts\`.

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx eslint <3 files>\` — 0 errors (6 pre-existing warnings)
- [x] Build worktree at \`pqctoday-hub-learn-track-a-bug-fixes-06012026\` — diff matches the planned 3-file/33-line change exactly
- [ ] Manual UX verification at \`/learn/network-security-pqc\` step 6 (ErrorBoundary must not trigger)
- [ ] Manual UX verification at \`/learn/pqc-candidates\` and \`/learn/crypto-agility\` (Complete Module ✓ must flip status badge on module card)
- [ ] Spot-check another module in the 20-module list (e.g. KmsPqc, QuantumThreats) — should auto-complete without code change

## Out of scope

- **Track B (UX/content)**: ENISA-column drop, QRNG entropy demo
- **Track C (crypto routing)**: Silithium FUSED → noble keygen, softhsm WASM load diagnosis
- **Track D (WASM rebuild)**: composite KEM cert, KCV-after-unwrap (separate PR in \`pqctoday-hsm\`)
- **Bug #10 (KMS envelope KCV)**: spec-compliance fix shipped in pqctoday-hsm; needs WASM rebuild + this hub doesn't yet pick up the new bundle

## Spec / standards references

- PKCS#11 v3.2 §5.5.6 (\`C_GetMechanismInfo\`) — the inspector that surfaces the mechanism names
- The 5 new mechanism codes are cross-referenced against \`pqctoday-hsm/src/wasm/softhsm.ts\` exported \`CKM_*\` constants (lines 604+) and the OASIS spec's mechanism tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)