### PR TITLE
fix(hybrid-crypto): route Pure PQC KEM cert (RFC 9935) through HSM via pkcs11-provider

### DIFF
--- a/src/components/PKILearning/modules/HybridCrypto/services/HybridCryptoService.ts
+++ b/src/components/PKILearning/modules/HybridCrypto/services/HybridCryptoService.ts
@@ -1,6 +1,17 @@
 // SPDX-License-Identifier: GPL-3.0-only
 import type { HsmFamily, HsmKeyRole } from '@/components/Playground/hsm/HsmContext'
 import { openSSLService } from '@/services/crypto/OpenSSLService'
+// NOTE: `CMSSigningService` is misnamed for our usage here — we only invoke
+// its X.509 cert-issuance half (`genKey` + `mkCert`), which calls
+// `openssl req -x509 -provider pkcs11 …` under the hood. That is NOT CMS;
+// it's plain X.509 minting via pkcs11-provider. We borrow the service
+// because it already owns a Worker with pkcs11-provider preloaded and
+// because the same code path already proves out KEM-only CA-issued certs
+// in MLKEMEncryptDemo. See the architectural-debt note at
+// `memory/project-pkcs-hsm-service-naming.md` — the right long-term fix is
+// to factor a `PkcsHsmCryptoService` layer (Option 2) that both
+// CMSSigningService and HybridCryptoService delegate to.
+import { CMSSigningService } from '@/components/PKILearning/modules/EmailSigning/services/CMSSigningService'
 import { generateX25519KeyPair, deriveSharedSecret, hkdfExtract } from '@/utils/webCrypto'
 import type { SoftHSMModule } from '@/wasm/softhsm'
 import { x25519 } from '@noble/curves/ed25519.js'
@@ -90,6 +101,33 @@ export type KeyTracker = (
 ) => void
 
 export class HybridCryptoService {
+  // Lazy-init CMSSigningService for HSM-routed cert ops (Pure PQC KEM,
+  // composite KEM, anywhere we need pkcs11-provider + softhsmv3 instead
+  // of bare openssl genpkey/req). One Worker per HybridCryptoService
+  // singleton — kept alive for the session.
+  // TODO: extract a shared PkcsHsmWorker layer when a third consumer
+  // beyond EmailSigning + HybridCrypto appears.
+  private cmsService: CMSSigningService | null = null
+  private cmsInitPromise: Promise<void> | null = null
+
+  private async getCms(): Promise<CMSSigningService> {
+    if (!this.cmsService) {
+      this.cmsService = new CMSSigningService()
+    }
+    if (!this.cmsInitPromise) {
+      this.cmsInitPromise = (async () => {
+        const r = await this.cmsService!.initProvider()
+        if (r.status !== 'ok' && r.status !== 'already') {
+          // Reset so a future call can retry from scratch.
+          this.cmsInitPromise = null
+          throw new Error(`pkcs11-provider init failed: ${r.status} (${r.code}) ${r.detail ?? ''}`)
+        }
+      })()
+    }
+    await this.cmsInitPromise
+    return this.cmsService
+  }
+
   private getGenCommand(algorithm: string, filename: string): string {
     if (algorithm === 'EC') {
       return `openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 -out ${filename}`
@@ -930,10 +968,18 @@ export class HybridCryptoService {
   /**
    * Pure PQC KEM certificate: ML-KEM-512/768/1024 per RFC 9935.
    *
-   * KEM keys cannot self-sign (RFC 9935 §4: encryption-only). Workshop simplification:
-   * generate an ML-DSA-65 transient issuer to act as a one-shot CA, and embed the ML-KEM
-   * public key via OpenSSL's `-force_pubkey`. In production deployments the CA must be
-   * pre-provisioned; this is purely an educational illustration of the wire format.
+   * KEM keys cannot self-sign (RFC 9935 §4: encryption-only). We mint a
+   * transient ML-DSA-65 issuer and CA-sign the KEM subject cert. Both
+   * keys are HSM-resident via softhsmv3 + pkcs11-provider; OpenSSL never
+   * sees raw key material, mirroring the S/MIME workshop's KEM-only flow
+   * in MLKEMEncryptDemo.
+   *
+   * Why HSM instead of OpenSSL `genpkey + req -force_pubkey`: the
+   * filesystem-key path was producing 0-byte certs in our 5.4 MB
+   * openssl.wasm bundle (RFC 9935 cert issuance via -force_pubkey isn't
+   * reliable for ML-KEM SPKI). Routing through pkcs11-provider's mkcert
+   * path produces a real PEM byte-identical to what an HSM-backed CA
+   * would emit in production.
    *
    * RFC 9935 OIDs:
    *   id-alg-ml-kem-512   = 2.16.840.1.101.3.4.4.1
@@ -946,58 +992,53 @@ export class HybridCryptoService {
   ): Promise<CertResult> {
     const start = performance.now()
     const tag = variant.toLowerCase().replace(/-/g, '_')
-    const kemKeyFile = `kem_${tag}_priv.pem`
-    const issuerKeyFile = `kem_${tag}_issuer.pem`
-    const certFile = `kem_${tag}_cert.pem`
-    const subj = `/CN=${cn}/O=PQC Today/OU=Hybrid Certificate Sandbox`
+    const kemKeyId = `kem_${tag}_priv`
+    const issuerKeyId = `kem_${tag}_issuer`
+    const certId = `kem_${tag}_cert`
+    const subject = `/CN=${cn}/O=PQC Today/OU=Hybrid Certificate Sandbox`
 
     try {
-      // 1. Generate the ML-KEM subject key (encryption-only).
-      const kemKey = await this.generateKey(variant, kemKeyFile)
-      if (kemKey.error || !kemKey.fileData) {
+      const cms = await this.getCms()
+
+      // 1. Generate the ML-KEM subject key in the HSM (encryption-only).
+      await cms.genKey(variant, kemKeyId, true)
+
+      // 2. Generate the ML-DSA-65 issuer key in the HSM.
+      await cms.genKey('ML-DSA-65', issuerKeyId, true)
+
+      // 3. CA-issue the cert. pkcs11-provider signs the SPKI containing
+      //    the ML-KEM pubkey using the ML-DSA-65 issuer key. No raw key
+      //    material leaves the HSM.
+      const cert = await cms.mkCert({
+        keyId: kemKeyId,
+        certId,
+        subject,
+        days: 365,
+        useHsm: true,
+        issuerKeyId,
+        alg: variant,
+      })
+
+      if (!cert.certPem) {
         return {
           pem: '',
           parsed: '',
           timingMs: performance.now() - start,
-          error: kemKey.error || `${variant} key generation failed`,
+          error: `${variant} CA-signed cert returned empty PEM`,
         }
       }
 
-      // 2. Generate a transient ML-DSA-65 issuer key to sign the cert (KEM keys cannot sign).
-      const issuerKey = await this.generateKey('ML-DSA-65', issuerKeyFile)
-      if (issuerKey.error || !issuerKey.fileData) {
-        return {
-          pem: '',
-          parsed: '',
-          timingMs: performance.now() - start,
-          error: issuerKey.error || 'Issuer (ML-DSA-65) key generation failed',
-        }
-      }
-
-      // 3. Issue cert: issuer signs; -force_pubkey embeds the ML-KEM key as subjectPublicKey.
-      //    OpenSSL 3.5+ supports -force_pubkey on `req -x509`.
-      const certResult = await openSSLService.execute(
-        `openssl req -new -x509 -key ${issuerKeyFile} -force_pubkey ${kemKeyFile} -out ${certFile} -days 365 -subj "${subj}"`,
-        [issuerKey.fileData, kemKey.fileData]
-      )
-      if (certResult.error) {
-        return {
-          pem: '',
-          parsed: '',
-          timingMs: performance.now() - start,
-          error: `${variant} cert issuance failed: ${certResult.error}`,
-        }
-      }
-
-      const certFileData = certResult.files.find((f) => f.name === certFile)
-      const pem = certFileData ? new TextDecoder().decode(certFileData.data) : ''
+      // 4. Parse the PEM for human-readable display. The PEM is plain
+      //    ASCII; we feed it to bare `openssl x509 -text -noout` (no HSM
+      //    needed for parsing).
+      const certBytes = new TextEncoder().encode(cert.certPem)
       const parsedResult = await openSSLService.execute(
-        `openssl x509 -in ${certFile} -text -noout`,
-        certFileData ? [{ name: certFile, data: certFileData.data }] : []
+        `openssl x509 -in ${certId}.pem -text -noout`,
+        [{ name: `${certId}.pem`, data: certBytes }]
       )
 
       return {
-        pem,
+        pem: cert.certPem,
         parsed: parsedResult.stdout || parsedResult.stderr || '',
         timingMs: performance.now() - start,
       }


### PR DESCRIPTION
## Summary

- Fixes the Pure ML-KEM-512/768/1024 cert path that was producing **0-byte certs** (user-reported via workshop screenshot, 2026-06-02).
- Reroutes from `openssl req -x509 -force_pubkey` (broken — no ML-KEM SPKI encoder in our bundle) to `pkcs11-provider`'s X.509 cert-issuance path, which IS wired in our bundle and already proven by the S/MIME workshop's MLKEMEncryptDemo.
- Bonus: ML-KEM private keys now live in softhsmv3 instead of as PEM files in the WASM VFS — honest to RFC 9935 §4's encryption-only posture and to the workshop's "real PKCS#11 v3.2 HSM demonstration" goal.

## Root cause

The old code called:

```
openssl req -new -x509 -key issuer.pem -force_pubkey kem.pem -out cert.pem ...
```

— but `-force_pubkey` needs an X.509 SubjectPublicKeyInfo encoder for the subject algorithm. Our 5.4 MB openssl.wasm exposes ML-KEM as a TLS named group (RFC 9145 key exchange) but does **not** provide an X.509 SPKI encoder. Result: step 3 silently emitted nothing, step 4 reported "Could not open file or uri for loading certificate from kem_ml_kem_768_cert.pem: No such file or directory".

## The fix

Route through `CMSSigningService.genKey` + `mkCert` with `useHsm=true`:

1. `cms.genKey('ML-KEM-768', kemKeyId, true)` — mint subject key in softhsmv3
2. `cms.genKey('ML-DSA-65', issuerKeyId, true)` — mint issuer key in softhsmv3
3. `cms.mkCert({ keyId, certId, subject, useHsm: true, issuerKeyId, alg: variant })` — CA-issue via `openssl req -x509 -provider pkcs11 …`. The SPKI encoder used here is pkcs11-provider's own (uses `C_GetAttributeValue` for raw key extraction).
4. `openssl x509 -text -noout` on the resulting PEM for the parsed display (HSM-independent — just ASCII parsing).

## RFC 9935 OIDs preserved

- `id-alg-ml-kem-512`  = 2.16.840.1.101.3.4.4.1
- `id-alg-ml-kem-768`  = 2.16.840.1.101.3.4.4.2
- `id-alg-ml-kem-1024` = 2.16.840.1.101.3.4.4.3

## Architectural note (also in commit body)

`CMSSigningService` is misnamed for our usage here — we only invoke its X.509 cert-issuance half (`genKey` + `mkCert`), which is plain `openssl req -x509 -provider pkcs11 …`, NOT CMS. We borrow the service because it already owns a Worker with pkcs11-provider preloaded. The long-term fix (when a 3rd HSM consumer appears) is to factor a shared `PkcsHsmCryptoService` layer that both `CMSSigningService` and `HybridCryptoService` delegate to. Tracked in `project-pkcs-hsm-service-naming.md`.

The Composite KEM path (X25519+ML-KEM-768, LAMPS draft) is unchanged — still on @noble per PR #278 because pkcs11-provider has no composite-KEM SPKI encoder yet.

## Depends on

- **PR #280** (openssl.wasm rebuild) — the new bundle picks up softhsmv3 PR #61's KCV fix AND the latest pkcs11-provider/softhsmv3 archives. The mkCert path here uses provider symbols only present after that rebuild.

## Test plan

- [x] `tsc -b` clean
- [x] ESLint clean
- [x] Full vitest suite: 3157 passed (2 pre-existing failures in `corpus-trust-invariants.test.ts` — rag-corpus vs embeddings-meta drift, exists on `origin/main`, unrelated)
- [ ] **Manual in-browser smoke** — `/learn/hybrid-crypto` → Cert Formats workshop → "Pure PQC KEM (ML-KEM-768) Demo". Cert PEM should render with real content (>0 bytes), Parsed view should show RFC 9935 OID + ML-DSA-65 issuer signature.
- [ ] Regression check on ML-KEM-512 and ML-KEM-1024 variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)