### PR TITLE
fix(hybrid-crypto): mint transient CA self-signed cert before CA-issuing the ML-KEM cert

### DIFF
--- a/src/components/PKILearning/modules/HybridCrypto/services/HybridCryptoService.ts
+++ b/src/components/PKILearning/modules/HybridCrypto/services/HybridCryptoService.ts
@@ -994,8 +994,13 @@ export class HybridCryptoService {
     const tag = variant.toLowerCase().replace(/-/g, '_')
     const kemKeyId = `kem_${tag}_priv`
     const issuerKeyId = `kem_${tag}_issuer`
+    // The cms.worker derives the issuer cert path from `${issuerKeyId}.crt`,
+    // so the issuer's self-signed cert MUST be minted with certId=issuerKeyId
+    // (see EmailSigning/worker/cms.worker.ts §3196 "Convention").
+    const issuerCertId = issuerKeyId
     const certId = `kem_${tag}_cert`
     const subject = `/CN=${cn}/O=PQC Today/OU=Hybrid Certificate Sandbox`
+    const issuerSubject = '/CN=PQC Workshop CA/O=PQC Today/OU=Transient Issuer'
 
     try {
       const cms = await this.getCms()
@@ -1006,9 +1011,21 @@ export class HybridCryptoService {
       // 2. Generate the ML-DSA-65 issuer key in the HSM.
       await cms.genKey('ML-DSA-65', issuerKeyId, true)
 
-      // 3. CA-issue the cert. pkcs11-provider signs the SPKI containing
-      //    the ML-KEM pubkey using the ML-DSA-65 issuer key. No raw key
-      //    material leaves the HSM.
+      // 3. Mint the issuer's self-signed CA cert. The cms.worker requires
+      //    `/ssl/<issuerKeyId>.crt` to exist before any CA-issued mkCert
+      //    call; otherwise it errors with "issuer cert not found". Mirrors
+      //    MLKEMEncryptDemo's CA-then-subject pattern.
+      await cms.mkCert({
+        keyId: issuerKeyId,
+        certId: issuerCertId,
+        subject: issuerSubject,
+        days: 730,
+        useHsm: true,
+      })
+
+      // 4. CA-issue the subject cert. pkcs11-provider signs the SPKI
+      //    containing the ML-KEM pubkey using the ML-DSA-65 issuer key.
+      //    No raw key material leaves the HSM.
       const cert = await cms.mkCert({
         keyId: kemKeyId,
         certId,


### PR DESCRIPTION
## Summary

Followup to PR #281. The Pure-KEM-via-HSM flow was missing a step — it skipped the CA's self-signed cert mint, so every Pure ML-KEM-768 cert generation failed with:

```
issuer cert not found: /ssl/kem_ml_kem_768_issuer.crt —
caller must mint the CA cert before issuing a subject cert from it
```

## Root cause

`cms.worker.ts` ([line 3196-3207](src/components/PKILearning/modules/EmailSigning/worker/cms.worker.ts#L3196-L3207)) requires the issuer's cert to already exist at `/ssl/<issuerKeyId>.crt` whenever an `issuerKeyId` is passed to `mkCert`. PR #281 minted the issuer KEY but never the issuer's CERT.

The correct pattern (matches `EmailSigning/MLKEMEncryptDemo`) is 4 steps:

1. `genKey('ML-KEM-768', kemKeyId, useHsm=true)` — subject key
2. `genKey('ML-DSA-65', issuerKeyId, useHsm=true)` — issuer key
3. **`mkCert({ keyId: issuerKeyId, certId: issuerKeyId, ... })` — CA self-sign (new)**
4. `mkCert({ keyId: kemKeyId, certId, issuerKeyId, ... })` — CA-issued subject cert

**Key detail:** `certId` for the issuer's self-signed cert must equal `issuerKeyId` so the worker's path derivation (`/ssl/${issuerKeyId}.crt`) finds it on the subsequent CA-issued call.

## Test plan

- [x] `tsc -b` clean
- [x] **In-browser verified** at `/learn/hybrid-crypto` → Cert Formats workshop → "Pure PQC KEM (ML-KEM-768) Demo". Cert now produces a real RFC 9935 PEM. The DER:0B / "No such file or directory" error is gone.
- [ ] CI green
- [ ] Post-merge Pages deploy verified live

## Closes

The Pure-KEM-via-HSM bug (Pure ML-KEM-768 cert generation) — finally end-to-end on the live site after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)