### PR TITLE
feat(learn): NICE view hides non-relevant CAs + modules when role is picked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Format: `## [MAJOR.MINOR.PATCH] - YYYY-MM-DD`. Latest release first.
 
 ## [Unreleased]
 
+### Changed
+
+- **Learn → NICE view: hide non-relevant competency areas + modules when a role is picked** [view:/learn]: Previously, picking a NICE Work Role (e.g. "Security Architect") greyed-out non-core Competency Areas to `opacity-40` and dimmed individual modules to `opacity-60`, leaving all 37+ modules on screen at lower contrast — visually busy. Now: non-core CAs are hidden entirely, and within each remaining CA the module list is filtered to those whose `workRoles` array includes the picked role. `All Roles` (the default) is unchanged and still shows the full catalog. The `isSecondaryCA` opacity-60 (for modules appearing in a "borrowed" CA where their primary CA is elsewhere) is preserved — that's a different visual signal independent of role filtering. The "Core for {role}" badge + the role-summary "X/Y relevant modules completed" line continue to provide context. Cleanup is opacity removal + early-return: ~16 lines in [NiceView.tsx](src/components/PKILearning/NiceView.tsx).
+
 ### Fixed
 
 - **Learn-module factual inaccuracies — second-pass audit, four more defects in workshop sub-files** [view:/learn]:

--- a/src/components/PKILearning/NiceView.tsx
+++ b/src/components/PKILearning/NiceView.tsx
@@ -233,12 +233,21 @@ export function NiceView({ navigate, activePersonaId }: NiceViewProps) {
       {/* ── Competency Area sections ── */}
       {CA_ORDER.map((caId) => {
         const ca = NICE_COMPETENCY_AREAS[caId]
-        const caRefs = getModulesForCompetencyArea(caId)
-        if (caRefs.length === 0) return null
+        const allCaRefs = getModulesForCompetencyArea(caId)
+        if (allCaRefs.length === 0) return null
 
         const isCoreForRole =
           selectedRole !== 'all' && NICE_WORK_ROLES[selectedRole].competencyAreas.includes(caId)
-        const isDimmed = selectedRole !== 'all' && !isCoreForRole
+
+        // When a specific role is picked, hide non-core CAs entirely and
+        // filter modules to those tagged for that role. "All Roles" keeps
+        // the full catalog visible.
+        if (selectedRole !== 'all' && !isCoreForRole) return null
+        const caRefs =
+          selectedRole === 'all'
+            ? allCaRefs
+            : allCaRefs.filter((m) => m.workRoles.includes(selectedRole))
+        if (caRefs.length === 0) return null
 
         const caCompleted = caRefs.filter(
           (m) => moduleStates[m.moduleId]?.status === 'completed'
@@ -251,13 +260,7 @@ export function NiceView({ navigate, activePersonaId }: NiceViewProps) {
         }
 
         return (
-          <div
-            key={caId}
-            className={clsx(
-              'glass-panel overflow-hidden transition-opacity duration-200',
-              isDimmed ? 'opacity-40' : 'opacity-100'
-            )}
-          >
+          <div key={caId} className="glass-panel overflow-hidden">
             {/* CA header */}
             <div className="flex gap-0">
               {/* Accent strip */}
@@ -324,8 +327,9 @@ export function NiceView({ navigate, activePersonaId }: NiceViewProps) {
                         const mod = MODULE_CATALOG[ref.moduleId]
                         if (!mod) return null
                         const status = moduleStates[ref.moduleId]?.status ?? 'not-started'
-                        const isRoleMatch =
-                          selectedRole !== 'all' && ref.workRoles.includes(selectedRole)
+                        // Dim modules appearing in a "borrowed" CA (their
+                        // primary CA is elsewhere) so the duplicate listing
+                        // reads as secondary. Applies regardless of role.
                         const isSecondaryCA = ref.competencyAreas[0] !== caId
 
                         return (
@@ -341,7 +345,6 @@ export function NiceView({ navigate, activePersonaId }: NiceViewProps) {
                                 : status === 'in-progress'
                                   ? 'border-info/40 bg-info/5 hover:bg-info/10'
                                   : 'border-border bg-muted/20 hover:bg-muted/40',
-                              isRoleMatch && 'ring-1 ring-primary/50',
                               isSecondaryCA && 'opacity-60'
                             )}
                           >


### PR DESCRIPTION
## Summary

Cleans up the **NICE** tab on `/learn`. Previously, picking a NICE Work Role (e.g. "Security Architect") greyed-out non-core Competency Areas to `opacity-40` and dimmed off-role modules to `opacity-60` — all 37+ modules stayed on screen at lower contrast, reading as visually busy.

Now: when a role is picked, non-relevant CAs and modules are **hidden entirely**. "All Roles" (the default) is unchanged and still shows the full catalog.

## What changes

In [src/components/PKILearning/NiceView.tsx](src/components/PKILearning/NiceView.tsx):

- **Non-core Competency Areas** (`NICE_WORK_ROLES[role].competencyAreas`) — return `null` early instead of wrapping in `opacity-40`.
- **Modules within each remaining CA** — filtered to `ref.workRoles.includes(selectedRole)`.
- **Empty post-filter CAs** — return `null`.
- **`ring-1 ring-primary/50` role-match ring** — dropped; every visible module is by definition a role match, so the ring became redundant.

Preserved:

- **"All Roles" default** still shows the full catalog (37 modules across 8 CAs).
- **"Core for {role}" badge** on remaining CAs.
- **Role-summary line** at the top of the view ("X / Y relevant modules completed").
- **`isSecondaryCA` opacity-60 dim** for modules appearing in a "borrowed" CA (their primary CA is elsewhere). That's an orthogonal signal — independent of role filtering.

## Diff size

16 lines net change in one file.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/components/PKILearning/NiceView.tsx` — 0 errors (9 pre-existing warnings)
- [x] `npm run build` — green
- [ ] Visual smoke: `/learn`, click NICE tab, pick "Security Architect" → only Architect's core CAs visible, only Architect-tagged modules within them. Click "All Roles" → full catalog returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)