### PR TITLE
chore(gitignore): ignore *.code-workspace developer-local files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,6 +155,9 @@ scripts/original_hook.ts
 # Playwright local state
 e2e/playwright-state.json
 
+# VSCode workspace files (developer-local; synced to pqctoday-priv if useful)
+*.code-workspace
+
 # === Private development files (synced to pqc-timeline-app-priv) ===
 
 # AI / Agent config


### PR DESCRIPTION
## Summary

One-line `.gitignore` addition: pattern `*.code-workspace` matches any VSCode workspace file anywhere in the tree. These are developer-local editor configs and don't belong in the public repo.

An orphan `pqctoday main workspace.code-workspace` had been showing as untracked under `src/components/PKILearning/modules/QuantumThreats/` for several sessions; that file is being moved to pqctoday-priv in a parallel private-repo commit.

## Test plan

- [x] grep confirms no `.code-workspace` files are currently tracked
- [x] git status no longer shows the orphan as untracked once pattern lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)