### PR TITLE
chore: gitignore *.code-workspace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -381,3 +381,6 @@ pki/issued/
 !pki/ca/*.pem
 !pki/vendors/*.pem
 src/.!*!.DS_Store
+
+# VSCode workspace files (per-developer, never committed)
+*.code-workspace


### PR DESCRIPTION
## Summary

Adds `*.code-workspace` to `.gitignore`. VSCode workspace files are per-developer config — they should never be committed.

One such file had been accidentally saved inside `src/components/PKILearning/modules/QuantumThreats/` and persistently showed as untracked across sessions. The file itself has been moved to `pqctoday-priv/workspaces/` (private repo) where developer-local workspace configs belong.

## Diff

```
+# VSCode workspace files (per-developer, never committed)
+*.code-workspace
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)