### PR TITLE
ci(append-revision): mark job continue-on-error pending GitHub-App fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: checks
+    # Branch protection on main rejects the in-job `git push` with GH006;
+    # the trust-engine provenance log (public/data/revisions.jsonl) is frozen
+    # until issue #294 lands the GitHub-App-based fix. Marking continue-on-error
+    # so the false-red CI signal stops drowning real failures.
+    continue-on-error: true
     permissions:
       contents: write
       pull-requests: read


### PR DESCRIPTION
## Summary

Stop-gap for the silently failing \`append-revision\` post-merge job. Issue #294 tracks the durable fix.

## What's broken

\`append-revision\` writes a provenance row to \`public/data/revisions.jsonl\` after every main merge, then does a literal \`git push\` to \`main\`. Branch protection has rejected that push with \`GH006\` on every merge since 2026-06-02. The CI workflow shows red on every main push, even when format/lint/audit/build/unit/E2E all pass.

## What this PR does

Adds \`continue-on-error: true\` to the job with an inline comment pointing at issue #294 for the real fix. The job continues to run (and continues to fail internally), but the workflow status is "success".

```diff
 append-revision:
   runs-on: ubuntu-latest
   if: github.event_name == 'push' && github.ref == 'refs/heads/main'
   needs: checks
+  # Branch protection on main rejects the in-job \`git push\` with GH006;
+  # the trust-engine provenance log (public/data/revisions.jsonl) is frozen
+  # until issue #294 lands the GitHub-App-based fix. Marking continue-on-error
+  # so the false-red CI signal stops drowning real failures.
+  continue-on-error: true
```

## What this PR explicitly does NOT do

- Does not append any rows to \`revisions.jsonl\` — the gap from 2026-06-02 onward remains
- Does not change \`scripts/ci/append-revision.ts\` — that's where #294 will land its changes
- Does not introduce any new tokens or secrets

## Test plan

- [x] One-line YAML change; no script or app behavior changes
- [ ] CI green on this PR (only \`continue-on-error: true\` added; rest unchanged)
- [ ] After merge: next main push shows the \`append-revision\` job as ⚠️ "skipped (continue-on-error)" instead of ❌ "failure" in the workflow rollup

Refs #294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)