### PR TITLE
fix(sim/learn): sim embeds use redesigned Assess + Library; Learn opens on My Path

### DIFF
--- a/src/components/Assess/redesign/AssessViewRedesign.tsx
+++ b/src/components/Assess/redesign/AssessViewRedesign.tsx
@@ -69,9 +69,31 @@ const ASSESS_STEP_LABELS: { key: string; label: string }[] = Object.keys(ASSESS_
   (key, i) => ({ key, label: STEP_LABELS[i] ?? key })
 )
 
-export const AssessViewRedesign: React.FC = () => {
+export const AssessViewRedesign: React.FC<{
+  /** When true, renders headless inside the simulation: breadcrumb + PageHeader +
+   *  the report/business-center banners are hidden, deep-link params are backed by
+   *  local state (so it never corrupts the /simulation route), and completing the
+   *  assessment calls `onComplete` (close the embed) instead of navigating away. */
+  simEmbed?: boolean
+  onComplete?: () => void
+}> = ({ simEmbed = false, onComplete }) => {
   const navigate = useNavigate()
-  const [searchParams, setSearchParams] = useSearchParams()
+  // In the sim embed, back the deep-link params with LOCAL state so the wizard
+  // never reads/writes the /simulation route (it can't nest its own Router).
+  const [realSearchParams, realSetSearchParams] = useSearchParams()
+  const [embedSearchParams, setEmbedSearchParamsState] = useState(() => new URLSearchParams())
+  const searchParams = simEmbed ? embedSearchParams : realSearchParams
+  const setSearchParams: typeof realSetSearchParams = simEmbed
+    ? (nextInit) =>
+        setEmbedSearchParamsState((prev) => {
+          const next = new URLSearchParams(
+            typeof nextInit === 'function'
+              ? (nextInit(prev) as URLSearchParams)
+              : (nextInit as URLSearchParams)
+          )
+          return next.toString() === prev.toString() ? prev : next
+        })
+    : realSetSearchParams
   const {
     assessmentStatus,
     markComplete,
@@ -177,6 +199,12 @@ export const AssessViewRedesign: React.FC = () => {
   const generate = () => {
     markComplete()
     logAssessComplete(selectedPersona ?? 'unknown')
+    // Embedded in the sim → close back to the board (the sim owns the next move);
+    // never navigate away from /simulation or show the standalone done screen.
+    if (simEmbed) {
+      onComplete?.()
+      return
+    }
     // Came from a sim run (the locked-sim gate sent the player to /assess) →
     // return to the now-unlocked simulation instead of stranding them on the
     // done/report screen. The report stays reachable from inside the sim.
@@ -224,20 +252,24 @@ export const AssessViewRedesign: React.FC = () => {
 
   return (
     <div className="animate-fade-in">
-      <WorkflowBreadcrumb current="assess" />
-      <PageHeader
-        icon={ClipboardCheck}
-        pageId="assess"
-        title="PQC Risk Assessment"
-        description="Answer a few questions to get a personalized quantum risk score, migration priorities, and actionable recommendations for your organization."
-        dataSource={
-          metadata
-            ? `${metadata.filename} • Updated: ${metadata.lastUpdate.toLocaleDateString()}`
-            : undefined
-        }
-        shareTitle="PQC Risk Assessment — Post-Quantum Cryptography Migration Tool"
-        shareText="Get a personalized quantum risk score, migration priorities, and actionable recommendations for your organization."
-      />
+      {!simEmbed && (
+        <>
+          <WorkflowBreadcrumb current="assess" />
+          <PageHeader
+            icon={ClipboardCheck}
+            pageId="assess"
+            title="PQC Risk Assessment"
+            description="Answer a few questions to get a personalized quantum risk score, migration priorities, and actionable recommendations for your organization."
+            dataSource={
+              metadata
+                ? `${metadata.filename} • Updated: ${metadata.lastUpdate.toLocaleDateString()}`
+                : undefined
+            }
+            shareTitle="PQC Risk Assessment — Post-Quantum Cryptography Migration Tool"
+            shareText="Get a personalized quantum risk score, migration priorities, and actionable recommendations for your organization."
+          />
+        </>
+      )}
 
       {/* Phase overlay banner (additive). */}
       {phase && (
@@ -282,7 +314,7 @@ export const AssessViewRedesign: React.FC = () => {
       {/* Already-complete banner — lets a returning user choose: edit the
           answers below, or jump to their existing report. Hidden on the
           review/done screens (which carry their own report CTA). */}
-      {assessmentStatus === 'complete' && screen === 'wizard' && (
+      {!simEmbed && assessmentStatus === 'complete' && screen === 'wizard' && (
         <motion.div
           initial={{ opacity: 0, y: -10 }}
           animate={{ opacity: 1, y: 0 }}

--- a/src/components/Library/redesign/LibraryViewRedesign.tsx
+++ b/src/components/Library/redesign/LibraryViewRedesign.tsx
@@ -9,7 +9,7 @@
  * filter/sort/view/ref state in the URL (?cat/org/q/sort/view/lifecycle/cswp39/qv/
  * ref/prefs plus the geo[]/sector[]/tier params the shared filters own).
  */
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { BookOpen, X } from 'lucide-react'
 import { PageHeader } from '@/components/common/PageHeader'
@@ -51,8 +51,26 @@ const FILTER_PARAMS = [
   'tier',
 ]
 
-export function LibraryViewRedesign() {
-  const [params, setParams] = useSearchParams()
+export function LibraryViewRedesign({ simEmbed = false }: { simEmbed?: boolean } = {}) {
+  // When embedded in the sim, the library must NOT read/write the page URL (it
+  // would corrupt /simulation's route) and can't nest its own <Router>. So its
+  // filter URL state is backed by local state, kept API-compatible with
+  // useSearchParams. (Same pattern as the legacy LibraryView / MigrateView.)
+  const [realParams, realSetParams] = useSearchParams()
+  const [embedParams, setEmbedParamsState] = useState(() => new URLSearchParams())
+  const params = simEmbed ? embedParams : realParams
+  const setParams: typeof realSetParams = simEmbed
+    ? (nextInit) =>
+        setEmbedParamsState((prev) => {
+          const next = new URLSearchParams(
+            typeof nextInit === 'function'
+              ? (nextInit(prev) as URLSearchParams)
+              : (nextInit as URLSearchParams)
+          )
+          // keep object identity when unchanged so params-keyed effects don't loop
+          return next.toString() === prev.toString() ? prev : next
+        })
+    : realSetParams
   const selectedPersona = usePersonaStore((s) => s.selectedPersona)
   const setPersona = usePersonaStore((s) => s.setPersona)
   const libraryBookmarks = useBookmarkStore((s) => s.libraryBookmarks)
@@ -163,21 +181,23 @@ export function LibraryViewRedesign() {
 
   return (
     <div className="animate-fade-in space-y-4 pb-24">
-      <PageHeader
-        icon={BookOpen}
-        pageId="library"
-        title="PQC Library"
-        description="The standards, drafts and guidance that define post-quantum cryptography."
-        dataSource={
-          libraryMetadata
-            ? `${libraryMetadata.filename} • Updated: ${libraryMetadata.lastUpdate.toLocaleDateString()}`
-            : undefined
-        }
-        viewType="Library"
-        shareTitle="PQC Library — NIST, IETF, ETSI & More"
-        shareText="Explore post-quantum cryptography standards, drafts, and key documents."
-        onExport={handleExportCsv}
-      />
+      {!simEmbed && (
+        <PageHeader
+          icon={BookOpen}
+          pageId="library"
+          title="PQC Library"
+          description="The standards, drafts and guidance that define post-quantum cryptography."
+          dataSource={
+            libraryMetadata
+              ? `${libraryMetadata.filename} • Updated: ${libraryMetadata.lastUpdate.toLocaleDateString()}`
+              : undefined
+          }
+          viewType="Library"
+          shareTitle="PQC Library — NIST, IETF, ETSI & More"
+          shareText="Explore post-quantum cryptography standards, drafts, and key documents."
+          onExport={handleExportCsv}
+        />
+      )}
 
       <LibraryRoleLens
         selectedPersona={selectedPersona}

--- a/src/components/PKILearning/index.test.tsx
+++ b/src/components/PKILearning/index.test.tsx
@@ -34,8 +34,10 @@ describe('PKILearning', () => {
     usePersonaStore.setState({ selectedPersona: null, hasSeenPersonaPicker: true })
   })
 
-  // With no persona selected, the redesigned /learn defaults to Browse mode,
-  // which renders the full module catalog (no view-mode radio anymore).
+  // With no persona selected, the redesigned /learn defaults to "My Path" (the
+  // guided cold-start). The full module catalog lives under the "Browse all" tab.
+  const goToBrowse = () =>
+    fireEvent.click(screen.getByRole('button', { name: /browse all \d+ modules/i }))
 
   it('renders the redesigned Learn header and the module catalog', () => {
     renderWithRouter()
@@ -43,13 +45,15 @@ describe('PKILearning', () => {
     expect(screen.getByRole('heading', { name: 'Learn' })).toBeInTheDocument()
     expect(screen.getByText('Viewing as')).toBeInTheDocument()
 
-    // Browse mode shows the catalog cards
+    // Switch to Browse to see the catalog cards
+    goToBrowse()
     expect(screen.getByText('Digital Assets')).toBeInTheDocument()
     expect(screen.getByText('PKI')).toBeInTheDocument() // PKIWorkshop card title
   })
 
   it('navigates to Digital Assets module on click', async () => {
     renderWithRouter()
+    goToBrowse()
 
     fireEvent.click(screen.getByText('Digital Assets'))
 
@@ -61,6 +65,7 @@ describe('PKILearning', () => {
 
   it('navigates to PKI Workshop module on click', async () => {
     renderWithRouter()
+    goToBrowse()
 
     fireEvent.click(screen.getByText('PKI'))
 
@@ -71,6 +76,7 @@ describe('PKILearning', () => {
 
   it('allows navigating back from a module', async () => {
     renderWithRouter()
+    goToBrowse()
 
     fireEvent.click(screen.getByText('Digital Assets'))
     expect(

--- a/src/components/PKILearning/redesign/LearnRedesignView.tsx
+++ b/src/components/PKILearning/redesign/LearnRedesignView.tsx
@@ -38,9 +38,11 @@ export const LearnRedesignView = () => {
   const selectedPersona = usePersonaStore((s) => s.selectedPersona)
   const setPersona = usePersonaStore((s) => s.setPersona)
 
-  const [mode, setMode] = useState<Mode>(() =>
-    deepLinkNice || !selectedPersona ? 'browse' : 'path'
-  )
+  // First open defaults to "My Path" — the page's headline ("one guided path …
+  // tuned to your role"). With no role yet, My Path shows the cold-start prompt to
+  // pick a role; landing on the dense Browse catalog instead read as "off". Only
+  // the ?view=nice deep-link opens straight into Browse (the workforce lens).
+  const [mode, setMode] = useState<Mode>(() => (deepLinkNice ? 'browse' : 'path'))
   const [showRouter, setShowRouter] = useState(false)
 
   const pathSummary = usePersonaPathItems(selectedPersona)
@@ -171,10 +173,10 @@ export const LearnRedesignView = () => {
           />
         ) : (
           <div className="space-y-3">
-            <div className="glass-panel rounded-xl p-6 text-center space-y-3">
-              <p className="text-sm text-muted-foreground">
-                Pick a role above to get a guided path — or use the catalog.
-              </p>
+            <div className="glass-panel flex flex-wrap items-center justify-center gap-x-2.5 gap-y-2 rounded-xl px-4 py-3 text-center">
+              <span className="text-sm text-muted-foreground">
+                Pick a role above for a guided path — or
+              </span>
               <Button variant="outline" size="sm" onClick={() => setMode('browse')}>
                 Browse all {TOTAL_MODULE_COUNT} modules
               </Button>

--- a/src/components/Simulation/SimulationView.tsx
+++ b/src/components/Simulation/SimulationView.tsx
@@ -38,7 +38,7 @@ import { parseTimelineScope } from '@/data/timelineScope'
 import { MigrateWorkbenchEmbed } from '@/components/shared/widgets/MigrateWorkbenchEmbed'
 import { SandboxScenarioEmbed } from '@/components/Playground/SandboxScenarioEmbed'
 import { PlaygroundProvider } from '@/components/Playground/PlaygroundProvider'
-import { AssessWizard } from '@/components/Assess/AssessWizard'
+import { AssessViewRedesign } from '@/components/Assess/redesign/AssessViewRedesign'
 import { Button } from '@/components/ui/button'
 import {
   FRAMEWORK_PHASES,
@@ -1346,11 +1346,14 @@ export function SimulationView() {
                    screens (they have no page container in the sim). */}
             <div className="mx-auto w-full max-w-[1800px] px-4 md:px-6 lg:px-8">
               {assessEmbed ? (
-                // Re-run / refine the assessment in-sim. onComplete closes back to
-                // the board (NOT /report); the wizard writes to the assessment store,
-                // so assessSnap + the read-only org dials / derived maturity update.
-                <div className="mx-auto max-w-3xl p-4 md:p-6">
-                  <AssessWizard onComplete={closeEmbed} />
+                // Re-run / refine the assessment in-sim — the REDESIGNED /assess
+                // surface (track chooser + two-pane wizard), embedded headless.
+                // onComplete closes back to the board (NOT /report); the wizard
+                // writes to the assessment store, so assessSnap + the read-only org
+                // dials / derived maturity update. Two-pane layout → full width
+                // (no max-w-3xl, which would squish the rail + question pane).
+                <div className="p-1 md:p-2">
+                  <AssessViewRedesign simEmbed onComplete={closeEmbed} />
                 </div>
               ) : learnEmbed && LearnComp ? (
                 <EmbeddedLearnProvider>

--- a/src/components/shared/widgets/LibraryEmbed.tsx
+++ b/src/components/shared/widgets/LibraryEmbed.tsx
@@ -3,14 +3,17 @@
  * LibraryEmbed — renders the PQC Library inside the simulation (under the
  * "● Simulation mode" header) instead of navigating the player out to /library.
  *
- * LibraryView is URL-driven (it reads/writes filters via useSearchParams), which
- * inside /simulation would corrupt the sim's own route, and it can't be wrapped in
- * its own <Router> (React Router forbids nested routers). Its `simEmbed` prop backs
- * the filter URL state with LOCAL state and hides the PageHeader so the sim bar
- * stays on top — the same approach as MigrateEmbed/MigrateView.
+ * LibraryViewRedesign is URL-driven (it reads/writes filters via useSearchParams),
+ * which inside /simulation would corrupt the sim's own route, and it can't be
+ * wrapped in its own <Router> (React Router forbids nested routers). Its `simEmbed`
+ * prop backs the filter URL state with LOCAL state and hides the PageHeader so the
+ * sim bar stays on top — the same approach as MigrateEmbed/MigrateView.
+ *
+ * Renders the redesigned library (the default /library page) so the sim shows the
+ * same surface as the standalone route — NOT the legacy LibraryView (/library/legacy).
  */
-import { LibraryView } from '@/components/Library/LibraryView'
+import { LibraryViewRedesign } from '@/components/Library/redesign/LibraryViewRedesign'
 
 export function LibraryEmbed() {
-  return <LibraryView simEmbed />
+  return <LibraryViewRedesign simEmbed />
 }


### PR DESCRIPTION
Post-deploy hotfixes for three issues spotted on the live v4.x site.

## What was wrong
- **Assess embed** — the simulation's Assess phase rendered the *legacy* `AssessWizard`, while standalone `/assess` shows the redesign. Sim showed stale UI.
- **Library embed** — the sim's Library embed rendered the *legacy* `LibraryView`, while `/library` shows `LibraryViewRedesign`.
- **Learn no-role layout** — `/learn` opened on the dense **Browse** catalog when no role was selected (read as a broken layout); selecting a role flipped to the polished My Path.

## Fixes
- `LibraryViewRedesign` gains a `simEmbed` prop (local-state-backed filters + hidden PageHeader, same contract as the legacy view); `LibraryEmbed` renders the redesign.
- `AssessViewRedesign` gains `simEmbed` + `onComplete` (hides breadcrumb/header/complete-banner, local-backed deep-link params so it can't corrupt `/simulation`, and completes by closing the embed); `SimulationView` renders it instead of `AssessWizard`.
- `/learn` defaults to **My Path** on first open; the no-role cold-start is a compact prompt above the guided-routing tree. `?view=nice` still opens Browse.

All changes are **additive** — standalone `/assess` and `/library` behave exactly as before (gated behind `simEmbed`, default `false`).

**Verification:** `tsc -b` clean · 4009 tests pass · production build green · Learn no-role state screenshot-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)