### PR TITLE
fix(learn): stop Browse-all module cards overflowing on wide screens

### DIFF
--- a/src/components/PKILearning/ModuleCard.tsx
+++ b/src/components/PKILearning/ModuleCard.tsx
@@ -102,7 +102,7 @@ export const ModuleCard = ({
       animate={{ opacity: isAboveLevel && status !== 'completed' ? 0.4 : 1, scale: 1 }}
       exit={{ opacity: 0, scale: reduced ? 1 : 0.9 }}
       transition={{ duration: reduced ? 0 : 0.2 }}
-      className="glass-panel p-6 flex flex-col h-full transition-colors hover:border-secondary/50 cursor-pointer scroll-mt-20"
+      className="@container glass-panel p-6 flex flex-col h-full transition-colors hover:border-secondary/50 cursor-pointer scroll-mt-20"
       onClick={() => onSelectModule(module.id)}
     >
       <div className="flex items-start justify-between mb-4">
@@ -199,7 +199,7 @@ export const ModuleCard = ({
           )}
           <span
             className={
-              'px-3 py-1 rounded-full text-xs font-bold border ' +
+              'px-3 py-1 rounded-full text-xs font-bold border whitespace-nowrap ' +
               (status === 'completed'
                 ? 'bg-status-success text-status-success'
                 : status === 'in-progress'
@@ -235,10 +235,10 @@ export const ModuleCard = ({
         {module.description}
       </p>
 
-      <div className="flex items-center justify-between pt-4 border-t border-border">
-        <div className="flex items-center gap-2 text-xs md:text-sm text-muted-foreground">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-2 pt-4 border-t border-border">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs @sm:text-sm text-muted-foreground min-w-0">
           <Clock size={14} className="shrink-0" />
-          <span className="truncate max-w-[120px] md:max-w-none">{durationDisplay}</span>
+          <span className="whitespace-nowrap">{durationDisplay}</span>
           {module.difficulty && (
             <span
               className={
@@ -270,8 +270,8 @@ export const ModuleCard = ({
             </span>
           )}
         </div>
-        <div className="flex items-center gap-2 shrink-0">
-          <div className="hidden lg:flex items-center gap-2">
+        <div className="flex items-center gap-2 shrink-0 ml-auto">
+          <div className="hidden @lg:flex items-center gap-2">
             <EndorseButton
               endorseUrl={buildEndorsementUrl({
                 category: 'learn-module-endorsement',

--- a/src/components/PKILearning/redesign/BrowseAllView.tsx
+++ b/src/components/PKILearning/redesign/BrowseAllView.tsx
@@ -322,7 +322,7 @@ export const BrowseAllView = ({
                 <h3 className="text-sm font-semibold text-foreground">{g.track}</h3>
                 <span className="text-xs text-muted-foreground">{g.modules.length}</span>
               </div>
-              <div className="grid gap-2.5 [grid-template-columns:repeat(auto-fill,minmax(228px,1fr))]">
+              <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(320px,1fr))]">
                 {g.modules.map((m) => (
                   <ModuleCard
                     key={m.id}


### PR DESCRIPTION
## Problem
On the **Learn → Browse all** catalog, module cards spilled their content past the right border on wide screens (two reports with screenshots: badge wrapping/floating, then the footer row of chips + action icons running off the card edge).

Two root causes:
1. **Columns too narrow.** Browse-all forced the full-featured `ModuleCard` into `minmax(228px,1fr)` (~237px actual). That card is designed for the 1–2 column layouts used everywhere else (~350–700px). Squeezed to 237px, the header's right cluster collapsed and the "Not Started" badge wrapped to two lines.
2. **Viewport breakpoints inside a multi-column grid.** The footer used `md:`/`lg:` rules, which fire on screen width. On a wide monitor a 356px card still got the "wide-screen" footer (duration + chips + endorse/flag/assistant icons + Resume), so the row overflowed the card.

## Fix (layout-only)
- **`BrowseAllView`** — widen the grid to `minmax(320px,1fr)` with a `gap-4` gutter so cards render at the width they were built for.
- **`ModuleCard`** — make the card a CSS container (`@container`) so the footer responds to the **card's own width**, not the viewport:
  - footer chips now wrap instead of overflowing,
  - endorse/flag/assistant icons only appear once a card is actually wide (`@lg`), so they no longer crowd the dense browse cards (they still show in the 2-column layouts),
  - the status badge stays on a single line (`whitespace-nowrap`).

## Verification
- `tsc -b` ✅, `eslint` ✅ (only pre-existing warnings on untouched lines), 653 PKILearning unit tests ✅
- Verified visually in the running app: measured every card in Browse-all — none overflows its border; footer chips wrap cleanly within the card.

⚠️ Do not auto-merge — open for review, no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)