### PR TITLE
fix(learn): correct factual and vendor accuracy in module exercises

### DIFF
--- a/src/components/PKILearning/modules/CodeSigning/components/CodeSigningExercises.tsx
+++ b/src/components/PKILearning/modules/CodeSigning/components/CodeSigningExercises.tsx
@@ -60,7 +60,7 @@ export const CodeSigningExercises: React.FC<CodeSigningExercisesProps> = ({
       badge: 'Packages',
       badgeColor: 'bg-warning/20 text-warning border-warning/50',
       observe:
-        'Hybrid mode produces a signature of ~4,741 bytes (ML-DSA-87 + Ed448 combined), but older RPM tools can still verify using just the Ed448 portion. This is the approach Red Hat has chosen for RHEL 10.',
+        'Hybrid mode produces a signature of ~4,741 bytes (ML-DSA-87 + Ed448 combined), but older RPM tools can still verify using just the Ed448 portion. Dual-signature schemes like this are being explored as a backward-compatible path for Linux package signing.',
       config: { step: 2 },
     },
     {
@@ -71,7 +71,7 @@ export const CodeSigningExercises: React.FC<CodeSigningExercisesProps> = ({
       badge: 'Sigstore',
       badgeColor: 'bg-success/20 text-success border-success/50',
       observe:
-        'The key advantage of Sigstore is that no long-term private keys exist. The ephemeral ML-DSA-65 keypair lives for ~20 minutes, and the transparency log (Rekor) serves as the permanent verification anchor.',
+        'The key advantage of Sigstore is that no long-term private keys exist. The ephemeral keypair — ECDSA P-256 in Fulcio today, with ML-DSA-65 as the post-quantum upgrade — lives for ~20 minutes, and the transparency log (Rekor) serves as the permanent verification anchor.',
       config: { step: 3 },
     },
     {

--- a/src/components/PKILearning/modules/ComplianceStrategy/ComplianceStrategyExercises.tsx
+++ b/src/components/PKILearning/modules/ComplianceStrategy/ComplianceStrategyExercises.tsx
@@ -27,9 +27,9 @@ const EXERCISES = [
     id: 'ex-3',
     title: 'Scenario: Healthcare PQC Compliance Timeline',
     prompt:
-      'A hospital network must protect patient records (30-year retention) while complying with HIPAA and the upcoming NIST deprecation of RSA/ECC by 2030. Build a compliance timeline that includes assessment, hybrid deployment, and full PQC migration phases. Where does the HNDL risk window overlap with compliance deadlines?',
+      'A hospital network must protect patient records (30-year retention) while complying with HIPAA and the draft NIST IR 8547 deprecation of RSA/ECC by 2030. Build a compliance timeline that includes assessment, hybrid deployment, and full PQC migration phases. Where does the HNDL risk window overlap with compliance deadlines?',
     workshopHint:
-      'Use the Compliance Timeline Builder (Step 3) to overlay NIST and HIPAA deadlines with migration phases. Factor in the 2035 NIST disallowance date against 30-year data retention.',
+      'Use the Compliance Timeline Builder (Step 3) to overlay NIST and HIPAA deadlines with migration phases. Factor in the draft 2035 NIST IR 8547 disallowance date against 30-year data retention.',
   },
   {
     id: 'ex-4',
@@ -37,7 +37,7 @@ const EXERCISES = [
     prompt:
       'You operate data centers in Germany, France, and the UK. GDPR obligations apply alongside BSI TR-02102 and ANSSI hybrid PQC recommendations. Germany requires BSI-certified modules for classified workloads; France recommends hybrid schemes only. Identify where requirements align and where they conflict. What is your unified migration strategy?',
     workshopHint:
-      'Use the Regulatory Gap Assessment (Step 4) with Germany, France, and UK selected. Note that BSI mandates hybrid ML-KEM + X25519 while ANSSI currently recommends hybrids pending further analysis — these are compatible approaches.',
+      'Use the Regulatory Gap Assessment (Step 4) with Germany, France, and UK selected. Note that BSI requires hybrid ML-KEM + X25519 for classified workloads while ANSSI currently recommends hybrids pending further analysis — these are compatible approaches.',
   },
 ]
 

--- a/src/components/PKILearning/modules/ConfidentialComputing/components/ConfidentialComputingExercises.tsx
+++ b/src/components/PKILearning/modules/ConfidentialComputing/components/ConfidentialComputingExercises.tsx
@@ -35,11 +35,11 @@ export const ConfidentialComputingExercises: React.FC<ExercisesProps> = ({
       title:
         '1. TEE Architecture Selection — Choose the right TEE for ML model inference at a bank',
       description:
-        'In the TEE Architecture Explorer, compare Intel SGX (process-level isolation, 256 MB EPC) against AMD SEV-SNP (full VM encryption) for protecting ML model inference with customer data. Consider TCB size, memory limits, cloud availability, and PQC readiness.',
+        'In the TEE Architecture Explorer, compare Intel SGX (process-level isolation; ~256 MB EPC on legacy client parts, hundreds of GB on recent Xeon) against AMD SEV-SNP (full VM encryption) for protecting ML model inference with customer data. Consider TCB size, memory limits, cloud availability, and PQC readiness.',
       badge: 'Architecture',
       badgeColor: 'bg-primary/20 text-primary border-primary/50',
       observe:
-        'SGX has a smaller TCB (CPU + enclave only) but is limited to 256 MB EPC — too small for large ML models without partitioning. SEV-SNP encrypts the full VM including guest OS, which results in a larger TCB. Both are available on Azure and have distinct PQC attestation roadmaps.',
+        'SGX has a smaller TCB (CPU + enclave only); legacy client SGX was capped at ~256 MB EPC (too small for large ML models without partitioning), though recent Xeon server parts raise this to hundreds of GB. SEV-SNP encrypts the full VM including guest OS, which results in a larger TCB. Both are available on Azure and have distinct PQC attestation roadmaps.',
       config: { step: 0 },
     },
     {
@@ -61,7 +61,7 @@ export const ConfidentialComputingExercises: React.FC<ExercisesProps> = ({
       badge: 'Encryption',
       badgeColor: 'bg-status-warning/20 text-status-warning border-status-warning/50',
       observe:
-        'AES-128 effective security drops to 64-bit under Grover — below the NIST Level 1 threshold (128-bit post-quantum). ARM TrustZone and AWS Nitro use AES-256, which remains at 128-bit post-quantum security. Upgrade path: AES-XTS-256 in next-gen Intel/AMD CPUs.',
+        'The Grover calculator shows AES-128 brute-force search dropping from 2^128 to ~2^64 operations — the theoretical quadratic speedup. In practice that speedup is far less useful (Grover has enormous circuit depth and barely parallelizes), which is why NIST still rates AES-128 at security category 1. AES-256, used by ARM TrustZone and AWS Nitro, keeps a large margin and is the recommended choice for long-term (HNDL) confidentiality. Upgrade path: AES-XTS-256 in next-gen Intel/AMD CPUs.',
       config: { step: 2 },
     },
     {
@@ -94,7 +94,7 @@ export const ConfidentialComputingExercises: React.FC<ExercisesProps> = ({
       badge: 'Assessment',
       badgeColor: 'bg-secondary/20 text-secondary border-secondary/50',
       observe:
-        'Nitro attestation uses ECDSA P-384 (quantum-vulnerable). CloudHSM has ML-DSA preview via SDK only — no native PKCS#11 PQC support. AES-256 memory encryption is Grover-resilient. Patient records have long retention (HIPAA: 6+ years) making HNDL exposure critical. Overall: 3 of 5 layers need PQC migration, with attestation and TLS channel as highest priority.',
+        'Nitro attestation uses ECDSA P-384 (quantum-vulnerable). As of mid-2026, AWS CloudHSM exposes PQC mainly through SDK/preview paths rather than native PKCS#11 — confirm current support in AWS documentation. AES-256 memory encryption is Grover-resilient. Patient records have long retention (HIPAA: 6+ years) making HNDL exposure critical. Overall: 3 of 5 layers need PQC migration, with attestation and TLS channel as highest priority.',
       config: { step: 4 },
     },
   ]

--- a/src/components/PKILearning/modules/CryptoAgility/components/CryptoAgilityExercises.tsx
+++ b/src/components/PKILearning/modules/CryptoAgility/components/CryptoAgilityExercises.tsx
@@ -83,7 +83,7 @@ export const CryptoAgilityExercises: React.FC<CryptoAgilityExercisesProps> = ({
       badge: 'Full Plan',
       badgeColor: 'bg-success/20 text-success border-success/50',
       observe:
-        'The framework spans from discovery through monitoring. NSA CNSA 2.0 requires phased PQC adoption: exclusive use for web/browsers/networking by 2030, and exclusive use across all legacy NSS by 2033.',
+        'The framework spans from discovery through monitoring. NSA CNSA 2.0 (which applies to U.S. national security systems) sets phased deadlines: software/firmware signing and traditional networking reach exclusive PQC by 2030, while web browsers, cloud services, and operating systems follow by 2033.',
       config: { step: 2 },
     },
   ]

--- a/src/components/PKILearning/modules/CryptoDevAPIs/components/CryptoDevAPIsExercises.tsx
+++ b/src/components/PKILearning/modules/CryptoDevAPIs/components/CryptoDevAPIsExercises.tsx
@@ -58,7 +58,7 @@ export const CryptoDevAPIsExercises: React.FC<ExercisesProps> = ({
       badge: 'Patterns',
       badgeColor: 'bg-status-success/20 text-status-success border-status-success/50',
       observe:
-        'All three APIs use a two-phase pattern: (1) register/configure the provider at startup, (2) use algorithm-agnostic operations at runtime. JCA uses Security.addProvider() + Signature.getInstance("ML-DSA-65", "BC"). OpenSSL uses OSSL_PROVIDER_load() + EVP_PKEY_sign(). PKCS#11 uses C_Initialize() + CK_MECHANISM {CKM_ML_DSA_65, NULL, 0}. In all cases, the business logic (sign this buffer) is identical — only initialization differs.',
+        'All three APIs use a two-phase pattern: (1) register/configure the provider at startup, (2) use algorithm-agnostic operations at runtime. JCA uses Security.addProvider() + Signature.getInstance("ML-DSA-65", "BC"). OpenSSL uses OSSL_PROVIDER_load() + EVP_PKEY_sign(). PKCS#11 v3.2 uses C_Initialize() + CK_MECHANISM {CKM_ML_DSA, NULL, 0} (the parameter set such as ML-DSA-65 is selected via the CKA_PARAMETER_SET key attribute). In all cases, the business logic (sign this buffer) is identical — only initialization differs.',
       config: { step: 2 },
     },
     {
@@ -70,7 +70,7 @@ export const CryptoDevAPIsExercises: React.FC<ExercisesProps> = ({
       badge: 'Libraries',
       badgeColor: 'bg-status-warning/20 text-status-warning border-status-warning/50',
       observe:
-        "AWS-LC (Amazon's FIPS-validated fork) is the best fit: FIPS 140-3 validated, ML-KEM-768 in the FIPS module, Java bindings via aws-lc-rs-java. wolfSSL is also FIPS-validated and has ML-KEM support, making it a strong alternative especially for embedded POS terminal code. BoringSSL's \"BoringCrypto\" FIPS module is validated but limited to Google's internal use case.",
+        "As of mid-2026, AWS-LC (Amazon's FIPS-validated fork) is a strong fit: FIPS 140-3 validated, ML-KEM-768 in the FIPS module, Java bindings via aws-lc-rs-java. wolfSSL is also FIPS-validated and has ML-KEM support, making it a strong alternative especially for embedded POS terminal code. BoringSSL's \"BoringCrypto\" FIPS module is validated but limited to Google's internal use case. FIPS and PQC support move quickly, so confirm each option against the PQC Library Explorer and current CMVP listings.",
       config: { step: 4 },
     },
     {

--- a/src/components/PKILearning/modules/CryptoMgmtModernization/CryptoMgmtModernizationExercises.tsx
+++ b/src/components/PKILearning/modules/CryptoMgmtModernization/CryptoMgmtModernizationExercises.tsx
@@ -93,8 +93,8 @@ const EXERCISES = [
     badge: 'Mitigate/Migrate',
     badgeColor: 'bg-status-warning/20 text-status-warning border-status-warning/50',
     scenario:
-      'A 15-year-old PKI system issues SHA-1 certificates. The original development team is gone, the source code is partially unavailable, and the system cannot be taken offline. CSWP.39 §4.6 describes a "crypto gateway" option. Walk through the decision: gateway now + sunset plan, or emergency migration?',
-    hint: 'CSWP.39 §4.6: use a bump-in-the-wire when direct modification is infeasible. Key questions: Is there a scheduled replacement? Can the gateway itself be made agile? The gateway buys time — it is not a permanent solution. Model the sunset date in the ROI Builder. See the Visual tab for the Mitigation vs. Migration zones in the CSWP.39 process diagram.',
+      'A 15-year-old PKI system issues SHA-1 certificates. The original development team is gone, the source code is partially unavailable, and the system cannot be taken offline. CSWP.39 describes a "crypto gateway" option (a bump-in-the-wire). Walk through the decision: gateway now + sunset plan, or emergency migration?',
+    hint: 'CSWP.39: use a bump-in-the-wire (crypto gateway) when direct modification is infeasible. Key questions: Is there a scheduled replacement? Can the gateway itself be made agile? The gateway buys time — it is not a permanent solution. Model the sunset date in the ROI Builder. See the Visual tab for the Mitigation vs. Migration zones in the CSWP.39 process diagram.',
     step: 3,
   },
 ]

--- a/src/components/PKILearning/modules/DataAssetSensitivity/components/DataAssetExercises.tsx
+++ b/src/components/PKILearning/modules/DataAssetSensitivity/components/DataAssetExercises.tsx
@@ -40,7 +40,7 @@ export const DataAssetExercises: React.FC<DataAssetExercisesProps> = ({
       badge: 'HNDL',
       badgeColor: 'bg-status-error/20 text-status-error border-status-error/50',
       observe:
-        'With a 30-year retention period and High sensitivity, the HNDL risk year is 2034 − 30 = 2004. Data encrypted and collected as far back as 2004 is already in adversary archives. When you run this asset through the Sensitivity Scoring Engine (Step 4), the composite score will be ≥ 85 — placing it in the Critical urgency band. HIPAA + NIST IR 8547 compliance flags add further urgency.',
+        'With a 30-year retention period and High sensitivity, the HNDL risk year is 2034 − 30 = 2004. In effect, data collected as far back as 2004 (the CRQC year minus the retention period) is already in adversary archives. When you run this asset through the Sensitivity Scoring Engine (Step 4), the composite score will be ≥ 85 — placing it in the Critical urgency band. HIPAA + NIST IR 8547 compliance flags add further urgency.',
       config: { step: 0 },
     },
     {
@@ -62,7 +62,7 @@ export const DataAssetExercises: React.FC<DataAssetExercisesProps> = ({
       badge: 'Methodology',
       badgeColor: 'bg-secondary/20 text-secondary border-secondary/50',
       observe:
-        'NIST RMF categorizes the root CA as FIPS 199 "High" impact — CNSA 2.0 mandates migration by 2030 with ML-DSA-87 or SLH-DSA-256s. ISO 27005 scores it Critical risk (Likelihood 3 × Consequence 5 = 15) — treatment: Mitigate, immediate. FAIR ALE is highest for this asset because root CA compromise enables forging all certificates — catastrophic loss magnitude drives ALE into the tens of millions. DORA/NIS2 Protect pillar fails because RSA-4096 will no longer meet "state-of-the-art." The Priority Map recommends SLH-DSA-256s — stateless hash-based signatures offer the strongest long-term security assurance for key material with indefinite validity periods.',
+        'NIST RMF categorizes the root CA as FIPS 199 "High" impact — for national security systems, CNSA 2.0 specifies ML-DSA-87 for signing (with LMS/XMSS for software/firmware signing) on the 2030 timeline. ISO 27005 scores it Critical risk (Likelihood 3 × Consequence 5 = 15) — treatment: Mitigate, immediate. FAIR ALE is highest for this asset because root CA compromise enables forging all certificates — catastrophic loss magnitude drives ALE into the tens of millions. DORA/NIS2 Protect pillar fails because RSA-4096 will no longer meet "state-of-the-art." For a CNSA 2.0-scoped CA, the compliant choice is ML-DSA-87; where CNSA compliance is not required, the Priority Map highlights SLH-DSA (stateless hash-based) as the most conservative long-term option for key material with indefinite validity periods.',
       config: { step: 2 },
     },
     {

--- a/src/components/PKILearning/modules/DigitalID/components/DigitalIDExercises.tsx
+++ b/src/components/PKILearning/modules/DigitalID/components/DigitalIDExercises.tsx
@@ -28,7 +28,7 @@ const SCENARIOS: Scenario[] = [
     badge: 'Key Management',
     badgeColor: 'bg-primary/20 text-primary border-primary/50',
     observe:
-      'The wallet uses ECDSA P-256 for credential binding — the same key is used to sign presentation proofs sent to relying parties. Under a CRQC threat, harvested presentations could be used to forge proofs. ML-DSA-44 (FIPS 204) is the primary PQC replacement for wallet device keys.',
+      'The wallet uses ECDSA P-256 for credential binding — the same key is used to sign presentation proofs sent to relying parties. Under a CRQC threat, harvested presentations could be used to forge proofs. ML-DSA-44 (FIPS 204) is a leading PQC candidate for wallet device keys (its smaller signatures suit constrained wallets).',
     stepIndex: 0,
   },
   {
@@ -39,7 +39,7 @@ const SCENARIOS: Scenario[] = [
     badge: 'PID Issuance',
     badgeColor: 'bg-secondary/20 text-secondary border-secondary/50',
     observe:
-      'The PID is issued in mso_mdoc format (ISO 18013-5), signed by the national PID Issuer using ECDSA P-256. The issuer certificate is anchored to the national Trusted List. Per EUDI ARF 2.0, national PID issuers must publish PQC migration roadmaps by December 2026 and complete migration by December 2030.',
+      'The PID is issued in mso_mdoc format (ISO 18013-5), signed by the national PID Issuer using ECDSA P-256. The issuer certificate is anchored to the national Trusted List. The EU Coordinated Implementation Roadmap for PQC recommends national PQC roadmaps by 2026 and migration of high-risk use cases such as identity by 2030 — a policy recommendation rather than a binding EUDI ARF mandate.',
     stepIndex: 1,
   },
   {
@@ -61,7 +61,7 @@ const SCENARIOS: Scenario[] = [
     badge: 'QES / QTSP',
     badgeColor: 'bg-destructive/20 text-destructive border-destructive/50',
     observe:
-      "QES requires SCAL2 because the signing key must be under the sole control of the signatory — the QTSP must ensure no third party (including the QTSP itself) can sign on the user's behalf without their active authorisation. QTSPs are governed by ETSI EN 319 411 and listed on National Trusted Lists. The CSC API v2 (Cloud Signature Consortium) standardises the remote signing protocol.",
+      "QES requires SCAL2 because the signing key must be under the sole control of the signatory — the QTSP must ensure no third party (including the QTSP itself) can sign on the user's behalf without their active authorisation. QTSPs that issue qualified certificates follow ETSI EN 319 411, while remote QES signing with SCAL2 is governed by the ETSI EN 419 241 series (with the QSCD covered by EN 419 221-5); QTSPs are listed on National Trusted Lists. The CSC API v2 (Cloud Signature Consortium) standardises the remote signing protocol.",
     stepIndex: 4,
   },
   {

--- a/src/components/PKILearning/modules/EMVPaymentPQC/components/EMVPaymentExercises.tsx
+++ b/src/components/PKILearning/modules/EMVPaymentPQC/components/EMVPaymentExercises.tsx
@@ -61,7 +61,7 @@ export const EMVPaymentExercises: React.FC<ExercisesProps> = ({
       badge: 'Provisioning',
       badgeColor: 'bg-status-warning/20 text-status-warning border-status-warning/50',
       observe:
-        'RSA-2048 chain: ~1.5 KB (4 \u00d7 384 bytes). ML-DSA-44 chain: ~15.3 KB (4 \u00d7 3,832 bytes). FN-DSA-512: ~6.7 KB (4 \u00d7 1,687 bytes). FN-DSA is 10\u00d7 smaller than ML-DSA but 4.4\u00d7 larger than RSA. At 6.7 KB, FN-DSA fits within 32-64 KB card NVM but ML-DSA at 15.3 KB is tight. FN-DSA-512 has smaller signatures than ML-DSA-44, which reduces storage on size-constrained card NVM. ML-DSA-44 at 15.3 KB chain is tight for 32 KB NVM. FIPS 206 standardization for FN-DSA (Falcon) is pending.',
+        'RSA-2048 chain: ~1.5 KB (4 \u00d7 384 bytes). ML-DSA-44 chain: ~15.3 KB (4 \u00d7 3,832 bytes). FN-DSA-512: ~6.7 KB (4 \u00d7 1,687 bytes). FN-DSA is ~2.3\u00d7 smaller than ML-DSA but 4.4\u00d7 larger than RSA. At 6.7 KB, FN-DSA fits within 32-64 KB card NVM, while ML-DSA at 15.3 KB is tight for 32 KB NVM. FIPS 206 standardization for FN-DSA (Falcon) is still pending, so it is not yet a deployable option.',
       config: { step: 2 },
     },
     {

--- a/src/components/PKILearning/modules/ExecQuantumImpact/exercises.ts
+++ b/src/components/PKILearning/modules/ExecQuantumImpact/exercises.ts
@@ -18,6 +18,6 @@ export const EXEC_QUANTUM_EXERCISES: ExecExercise[] = [
   {
     title: 'Scenario: Compliance Deadline Collision',
     prompt:
-      'Your organization must comply with CNSA 2.0 (2030), DORA (2025), and NIS2 (2024) simultaneously. Budget is limited. Use the action plan builder to prioritize: which deadlines require immediate action versus which allow phased migration?',
+      'Your organization must navigate overlapping timelines: DORA (effective 2025), NIS2 (transposition 2024), and the draft NIST 2030 deprecation of RSA/ECC (NIST IR 8547). Budget is limited. Use the action plan builder to prioritize: which deadlines require immediate action versus which allow phased migration?',
   },
 ]

--- a/src/components/PKILearning/modules/HsmPqc/components/HsmPqcExercises.tsx
+++ b/src/components/PKILearning/modules/HsmPqc/components/HsmPqcExercises.tsx
@@ -73,7 +73,7 @@ export const HsmPqcExercises: React.FC<HsmPqcExercisesProps> = ({
       badge: 'Deployment',
       badgeColor: 'bg-success/20 text-success border-success/50',
       observe:
-        'No cloud HSM currently supports native PKCS#11 ML-KEM encapsulation in firmware. AWS CloudHSM offers ML-DSA preview via SDK only. For ML-KEM key exchange, an on-prem HSM (Thales, Entrust, Utimaco, or Crypto4A) is required today. Azure Dedicated HSM uses the same Thales Luna 7 hardware and gains full PQC once firmware is upgraded via Azure Support.',
+        'As of mid-2026, no cloud HSM supports native PKCS#11 ML-KEM encapsulation in firmware. AWS CloudHSM offers ML-DSA preview via SDK only. For ML-KEM key exchange, an on-prem HSM (Thales, Entrust, Utimaco, or Crypto4A) is required today. Azure Dedicated HSM uses the same Thales Luna 7 hardware and gains full PQC once firmware is upgraded via Azure Support.',
       config: { step: 1 },
     },
     {
@@ -84,7 +84,7 @@ export const HsmPqcExercises: React.FC<HsmPqcExercisesProps> = ({
       badge: 'Migration',
       badgeColor: 'bg-primary/20 text-primary border-primary/50',
       observe:
-        'With Thales Luna 7 (low complexity, 30-60 min/HSM), a rolling upgrade of 10 HSMs takes approximately 5-10 hours. The dual-partition strategy allows classical operations to continue during migration. No FIPS recertification is needed since existing FIPS 140-3 covers PQC firmware.',
+        'With Thales Luna 7 (low complexity, 30-60 min/HSM), a rolling upgrade of 10 HSMs takes approximately 5-10 hours. The dual-partition strategy allows classical operations to continue during migration. Note that adding PQC algorithms in new firmware generally requires fresh ACVP algorithm validations and a FIPS 140-3 module re-validation — the existing certificate does not automatically cover the new firmware, so budget for the CMVP timeline.',
       config: { step: 2 },
     },
     {
@@ -95,7 +95,7 @@ export const HsmPqcExercises: React.FC<HsmPqcExercisesProps> = ({
       badge: 'FIPS',
       badgeColor: 'bg-secondary/20 text-secondary border-secondary/50',
       observe:
-        'LMS has the most ACVP validations across vendors (Thales, Entrust, Utimaco, AWS). Full FIPS 140-3 module-level PQC validation is still limited to Thales Luna 7. Entrust nShield 5 has submitted for FIPS 140-3 but is pending. Algorithm-level ACVP validation is a prerequisite for module-level FIPS 140-3.',
+        'LMS has the most ACVP validations across vendors (Thales, Entrust, Utimaco, AWS). As of mid-2026, full FIPS 140-3 module-level PQC validation is limited to Thales Luna 7 (check the FIPS Validation Tracker for current status). Entrust nShield 5 has submitted for FIPS 140-3 but is pending. Algorithm-level ACVP validation is a prerequisite for module-level FIPS 140-3.',
       config: { step: 3 },
     },
   ]

--- a/src/components/PKILearning/modules/HybridCrypto/components/HybridCryptoExercises.tsx
+++ b/src/components/PKILearning/modules/HybridCrypto/components/HybridCryptoExercises.tsx
@@ -54,7 +54,7 @@ export const HybridCryptoExercises: React.FC<HybridCryptoExercisesProps> = ({
       badge: 'Signatures',
       badgeColor: 'bg-secondary/20 text-secondary border-secondary/50',
       observe:
-        'ML-DSA-65 private keys (4,032 bytes) are 126x larger than ECDSA P-256 (32 bytes). Signatures are 3,309 bytes vs 72 bytes. This is the main PQC migration challenge for bandwidth-constrained systems.',
+        'ML-DSA-65 private keys (4,032 bytes) are 126x larger than ECDSA P-256 (32 bytes). Signatures are 3,309 bytes vs 64 bytes (raw ECDSA; ~72 bytes when DER-encoded). This is the main PQC migration challenge for bandwidth-constrained systems.',
       config: { step: 0, category: 'signature' },
     },
     {

--- a/src/components/PKILearning/modules/IAMPQC/components/IAMPQCExercises.tsx
+++ b/src/components/PKILearning/modules/IAMPQC/components/IAMPQCExercises.tsx
@@ -49,7 +49,7 @@ export const IAMPQCExercises: React.FC<IAMPQCExercisesProps> = ({
       badge: 'Token Signing',
       badgeColor: 'bg-secondary/20 text-secondary border-secondary/50',
       observe:
-        'ML-DSA-65 signature (3,309 bytes) is ~13x larger than RS256 (256 bytes) and ~52x larger than ES256 (64 bytes). While signing takes only ~2.1ms (faster than most network round trips), the token size increase can impact HTTP Authorization header limits. Check your load balancer max header size.',
+        'ML-DSA-65 signature (3,309 bytes) is ~13x larger than RS256 (256 bytes) and ~52x larger than ES256 (64 bytes). ML-DSA signing is fast (typically a few milliseconds, well under most network round trips), but the token size increase can impact HTTP Authorization header limits. Check your load balancer max header size.',
       config: { step: 1 },
     },
     {
@@ -60,7 +60,7 @@ export const IAMPQCExercises: React.FC<IAMPQCExercisesProps> = ({
       badge: 'Directory',
       badgeColor: 'bg-warning/20 text-warning border-warning/50',
       observe:
-        'Active Directory exposes two critical HNDL vectors: PKINIT RSA decryption (Kerberos TGT traffic) and NTLM credential exposure. Microsoft Entra ID uses long-lived refresh tokens (90-day default) signed with RSA-2048, which are at risk under HNDL if intercepted.',
+        'Active Directory exposes two critical HNDL vectors: PKINIT RSA decryption (Kerberos TGT traffic) and NTLM credential exposure. Microsoft Entra ID issues long-lived refresh tokens; unlike access-token JWTs these are opaque, encrypted artifacts (not RSA-signed), so the main quantum exposure is the TLS transport and the RSA/ECDSA-signed access tokens (JWTs) minted from them.',
       config: { step: 2 },
     },
     {
@@ -71,7 +71,7 @@ export const IAMPQCExercises: React.FC<IAMPQCExercisesProps> = ({
       badge: 'Vendor PQC',
       badgeColor: 'bg-destructive/20 text-destructive border-destructive/50',
       observe:
-        "Microsoft Entra ID uses SymCrypt which supports ML-KEM and ML-DSA, and holds FedRAMP High certification. Keycloak (open-source) can be integrated with oqsprovider for PQC signing in self-hosted deployments. Roadmap timelines vary by vendor — check each vendor's public announcements for GA dates.",
+        "Microsoft Entra ID relies on SymCrypt, which has added ML-KEM and ML-DSA support (a separate matter from its FedRAMP High authorization). Keycloak (open-source) can be integrated with oqsprovider for PQC signing in self-hosted deployments. Roadmap timelines vary by vendor — check each vendor's public announcements for GA dates.",
       config: { step: 3 },
     },
     {
@@ -82,7 +82,7 @@ export const IAMPQCExercises: React.FC<IAMPQCExercisesProps> = ({
       badge: 'Zero Trust',
       badgeColor: 'bg-success/20 text-success border-success/50',
       observe:
-        'Session Management (hybrid TLS) can be migrated in 2025-2026 with zero application changes — start here for immediate quantum-safe coverage. Device Trust is the longest lead-time item (hardware replacement cycle); begin planning before 2026 even if deployment is 2027-2028.',
+        'Session Management (hybrid TLS) can be migrated now with zero application changes — start here for immediate quantum-safe coverage. Device Trust is the longest lead-time item (hardware replacement cycle); begin planning before 2026 even if deployment is 2027-2028.',
       config: { step: 4 },
     },
   ]

--- a/src/components/PKILearning/modules/IoTOT/components/IoTOTExercises.tsx
+++ b/src/components/PKILearning/modules/IoTOT/components/IoTOTExercises.tsx
@@ -82,8 +82,8 @@ export const IoTOTExercises: React.FC<IoTOTExercisesProps> = ({
       badge: 'BLE Mesh',
       badgeColor: 'bg-secondary/20 text-secondary border-secondary/50',
       observe:
-        'Due to tight payload limits, transmitting a 1,088-byte ML-KEM public key over standard BLE advertising channels is prohibitive. An out-of-band (OOB) PQC provisioning channel — such as QR codes or NFC — must be used to securely bootstrap the device before standard RF communications begin.',
-      config: { step: 4 },
+        'Due to tight payload limits, transmitting a 1,184-byte ML-KEM-768 public key (whose ciphertext is 1,088 bytes) over standard BLE advertising channels is prohibitive. An out-of-band (OOB) PQC provisioning channel — such as QR codes or NFC — must be used to securely bootstrap the device before standard RF communications begin.',
+      config: { step: 5 },
     },
     {
       id: 'scada-plan',
@@ -94,7 +94,7 @@ export const IoTOTExercises: React.FC<IoTOTExercisesProps> = ({
       badgeColor: 'bg-success/20 text-success border-success/50',
       observe:
         'The DMZ (Level 3.5) and enterprise boundary (Level 4\u20135) score highest migration priority because they are internet-facing and subject to HNDL. Level 0\u20131 devices may not need PQC directly if they are air-gapped, but gateway devices at Level 2 must protect data in transit from quantum threats.',
-      config: { step: 5 },
+      config: { step: 4 },
     },
   ]
 

--- a/src/components/PKILearning/modules/KmsPqc/components/KmsPqcExercises.tsx
+++ b/src/components/PKILearning/modules/KmsPqc/components/KmsPqcExercises.tsx
@@ -40,7 +40,7 @@ export const KmsPqcExercises: React.FC<KmsPqcExercisesProps> = ({
       badge: 'Hierarchy',
       badgeColor: 'bg-primary/20 text-primary border-primary/50',
       observe:
-        'Switching from Classical to PQC-only at the Root KEK level increases the public key from 256 bytes (RSA-4096) to 1,568 bytes (ML-KEM-1024). The tree visualization shows how mode choices cascade through the hierarchy.',
+        'Switching from Classical to PQC-only at the Root KEK level increases the public key from 512 bytes (RSA-4096) to 1,568 bytes (ML-KEM-1024). The tree visualization shows how mode choices cascade through the hierarchy.',
       config: { step: 0 },
     },
     {
@@ -73,7 +73,7 @@ export const KmsPqcExercises: React.FC<KmsPqcExercisesProps> = ({
       badge: 'Multi-Cloud',
       badgeColor: 'bg-destructive/20 text-destructive border-destructive/50',
       observe:
-        'AWS KMS has GA ML-DSA signing (ML-DSA-44/65/87) across all regions. Google Cloud KMS supports ML-KEM-768, ML-KEM-1024, X-Wing, ML-DSA-65, and SLH-DSA (preview). Azure Key Vault does not yet expose PQC key types natively; SymCrypt supports ML-KEM/ML-DSA internally but not through the Key Vault API.',
+        'As of mid-2026: AWS KMS has GA ML-DSA signing (ML-DSA-44/65/87, since 2025) in FIPS 140-3 Level 3 HSMs; Google Cloud KMS lists ML-KEM-768/1024, X-Wing, ML-DSA-65, and SLH-DSA in preview; Azure Key Vault is rolling out ML-KEM/ML-DSA key types via SymCrypt (2026-2027, tier/region dependent). Verify each provider current docs for the latest.',
       config: { step: 2 },
     },
     {
@@ -84,7 +84,7 @@ export const KmsPqcExercises: React.FC<KmsPqcExercisesProps> = ({
       badge: 'Compliance',
       badgeColor: 'bg-success/20 text-success border-success/50',
       observe:
-        'CNSA 2.0 requires all new NSS acquisitions to be PQC-compliant by 2027 and exclusively PQC by 2033. The storage impact multiplier ranges from 1.0x (AES-256 DEKs) to 30.0x (ECDSA → ML-DSA-65 code signing keys).',
+        'CNSA 2.0 phases PQC into U.S. national security systems by category: software/firmware signing and networking by 2030, with web, cloud, and operating systems following by 2033. The storage impact multiplier ranges from 1.0x (AES-256 DEKs) to 30.0x (ECDSA → ML-DSA-65 code signing keys).',
       config: { step: 3 },
     },
   ]

--- a/src/components/PKILearning/modules/MigrationProgram/MigrationProgramExercises.tsx
+++ b/src/components/PKILearning/modules/MigrationProgram/MigrationProgramExercises.tsx
@@ -11,9 +11,9 @@ const EXERCISES = [
     id: 'ex-1',
     title: 'Scenario: Financial Institution Migration',
     prompt:
-      'Your bank has 500+ applications using RSA-2048 and must comply with CNSA 2.0 by 2030. The CISO wants a 3-year migration roadmap. Build a phased roadmap with milestones, identify the top 5 stakeholders and their concerns, and define 4 KPIs to track progress. Consider regulatory deadlines from NIST, NSA, and your primary regulator.',
+      'Your bank has 500+ applications using RSA-2048 and must plan for the draft 2030 NIST deprecation of RSA/ECC (NIST IR 8547), alongside PQC expectations from its financial regulators. The CISO wants a 3-year migration roadmap. Build a phased roadmap with milestones, identify the top 5 stakeholders and their concerns, and define 4 KPIs to track progress. Consider regulatory drivers from NIST and your primary financial regulator (CNSA 2.0 applies to national security systems, not commercial banks).',
     workshopHint:
-      'Use the Roadmap Builder (Step 1) to lay out phases against the CNSA 2.0 2030 deadline. Map stakeholders in the Stakeholder Comms Planner (Step 2). Define weighted KPIs in the KPI Tracker (Step 3). Review the Deployment Playbook (Step 4) for execution checklists.',
+      'Use the Roadmap Builder (Step 1) to lay out phases against the 2030 NIST deprecation timeline. Map stakeholders in the Stakeholder Comms Planner (Step 2). Define weighted KPIs in the KPI Tracker (Step 3). Review the Deployment Playbook (Step 4) for execution checklists.',
   },
   {
     id: 'ex-2',

--- a/src/components/PKILearning/modules/NetworkSecurityPQC/components/NetworkSecurityExercises.tsx
+++ b/src/components/PKILearning/modules/NetworkSecurityPQC/components/NetworkSecurityExercises.tsx
@@ -51,7 +51,7 @@ export const NetworkSecurityExercises: React.FC<NetworkSecurityExercisesProps> =
       badge: 'TLS Inspection',
       badgeColor: 'bg-secondary/20 text-secondary border-secondary/50',
       observe:
-        'Hybrid ECDSA+ML-DSA-65 chains (8.5KB) exceed the 4KB buffer limit on most 2025 NGFW firmware, causing silent inspection bypass. Full inspection latency jumps from 9ms (ECDSA) to 28ms (hybrid) — a 3x increase critical for real-time applications. Pass-through mode adds zero latency but loses Layer 7 visibility.',
+        'Hybrid ECDSA+ML-DSA-65 chains (~8.5KB) can exceed the small certificate buffers in many current NGFW firmware builds, causing silent inspection bypass. The simulator projects full-inspection latency rising several-fold (roughly 9ms to 28ms in this model) — significant for real-time applications. Pass-through mode adds zero latency but loses Layer 7 visibility.',
       config: { step: 1 },
     },
     {
@@ -73,7 +73,7 @@ export const NetworkSecurityExercises: React.FC<NetworkSecurityExercisesProps> =
       badge: 'Vendor Matrix',
       badgeColor: 'bg-destructive/20 text-status-error border-destructive/50',
       observe:
-        'Only Palo Alto (PAN-OS 11.x) supports partial PQC TLS inspection in 2026. Cisco and Fortinet are in beta with full inspection planned for late 2026. Check Point, Sophos, and SonicWall are on 2027 roadmaps. Open-source pfSense/OPNsense already supports hybrid ML-KEM via OpenSSL 3.x but lacks TLS inspection capability.',
+        'Vendor support varies widely and moves fast: as of mid-2026 Palo Alto (PAN-OS 11.x) leads with partial PQC TLS inspection, while Cisco and Fortinet are earlier-stage and several others are on later roadmaps. Open-source pfSense/OPNsense already supports hybrid ML-KEM via OpenSSL 3.x but lacks TLS inspection. Use the Vendor Matrix for current per-vendor status rather than relying on fixed dates.',
       config: { step: 3 },
     },
     {

--- a/src/components/PKILearning/modules/OSPQC/components/OSPQCExercises.tsx
+++ b/src/components/PKILearning/modules/OSPQC/components/OSPQCExercises.tsx
@@ -49,7 +49,7 @@ export const OSPQCExercises: React.FC<OSPQCExercisesProps> = ({
       badge: 'TLS',
       badgeColor: 'bg-secondary/20 text-secondary border-secondary/50',
       observe:
-        'RHEL requires update-crypto-policies --set FUTURE (experimental, disables TLS 1.2). Ubuntu only needs a Groups= line in openssl.cnf — no TLS 1.2 disruption. Windows Server 2025 already has X25519MLKEM768 enabled by default via KB5036893 — zero configuration needed.',
+        'RHEL requires update-crypto-policies --set FUTURE (experimental, disables TLS 1.2). Ubuntu only needs a Groups= line in openssl.cnf — no TLS 1.2 disruption. Windows Server 2025 has begun shipping X25519MLKEM768 support through its 2025-2026 servicing updates (verify the exact build/KB and whether it is on by default in your image).',
       config: { step: 1 },
     },
     {
@@ -60,7 +60,7 @@ export const OSPQCExercises: React.FC<OSPQCExercisesProps> = ({
       badge: 'SSH',
       badgeColor: 'bg-warning/20 text-warning border-warning/50',
       observe:
-        'ML-DSA-65 host keys are 1,952 bytes public / 3,309 bytes signature — vs Ed25519 at 32 bytes / 64 bytes. As of March 2026, no production SSH client supports ssh-mldsa65 — all clients fall back to Ed25519. ML-KEM hybrid key exchange (sntrup761x25519) is already available in OpenSSH 8.5+ stable for session encryption.',
+        'ML-DSA-65 host keys are 1,952 bytes public / 3,309 bytes signature — vs Ed25519 at 32 bytes / 64 bytes. As of mid-2026, ML-DSA SSH host keys are not yet standardized in mainstream OpenSSH, so clients fall back to Ed25519 host keys. For session encryption a hybrid key exchange has been available longer: sntrup761x25519 (Streamlined NTRU Prime + X25519) since OpenSSH 8.5, and the ML-KEM-based mlkem768x25519-sha256 since OpenSSH 9.9 (the default since OpenSSH 10.0).',
       config: { step: 2 },
     },
     {
@@ -82,7 +82,7 @@ export const OSPQCExercises: React.FC<OSPQCExercisesProps> = ({
       badge: 'FIPS',
       badgeColor: 'bg-success/20 text-success border-success/50',
       observe:
-        'Windows Server 2025 (SymCrypt 103.4.0) is the only platform with ML-KEM in a FIPS 140-3 validated module today. RHEL 9 FIPS mode blocks ML-KEM. The recommended approach: keep FIPS for regulated workloads, use dual-provider config for new PQC services, then consolidate when RHEL 10/Ubuntu 26.04 FIPS PQC modules are certified.',
+        'As of mid-2026, FIPS 140-3 validated ML-KEM in an OS module is still rare (Windows Server 2025 / SymCrypt is among the first). On RHEL, FIPS mode exposes only the FIPS-curve ML-KEM hybrids (e.g. SecP256r1MLKEM768, added in RHEL 9.7) — standalone PQC is not yet in the validated FIPS provider, so it remains a FIPS-vs-PQC trade-off. Verify each platform against current CMVP listings. The recommended approach: keep FIPS for regulated workloads, use dual-provider config for new PQC services, then consolidate when RHEL 10/Ubuntu 26.04 FIPS PQC modules are certified.',
       config: { step: 4 },
     },
   ]

--- a/src/components/PKILearning/modules/PQCGovernance/PQCGovernanceExercises.tsx
+++ b/src/components/PKILearning/modules/PQCGovernance/PQCGovernanceExercises.tsx
@@ -43,7 +43,7 @@ const EXERCISES = [
     badge: 'Escalation',
     badgeColor: 'bg-status-error/20 text-status-error border-status-error/50',
     scenario:
-      'Six months before your CNSA 2.0 compliance deadline, your HSM vendor announces that ML-KEM support will be delayed by 12 months due to a supply chain issue. Your entire key management infrastructure depends on this vendor. Three regulated product lines face potential non-compliance. The program manager has already tried and failed to negotiate an interim solution.',
+      'Six months before your CNSA 2.0 milestone deadline (exclusive PQC for the earliest NSS categories by 2030), your HSM vendor announces that ML-KEM support will be delayed by 12 months due to a supply chain issue. Your entire key management infrastructure depends on this vendor. Three regulated product lines face potential non-compliance. The program manager has already tried and failed to negotiate an interim solution.',
     hint: 'Use the Escalation Framework (Step 4) to determine which tier owns this decision. Score the situation using the Exception Request Builder — set Vendor Dependency and Compliance Window to "Yes" and identify appropriate compensating controls.',
     step: 3,
   },

--- a/src/components/PKILearning/modules/PQCRiskManagement/PQCRiskManagementExercises.tsx
+++ b/src/components/PKILearning/modules/PQCRiskManagement/PQCRiskManagementExercises.tsx
@@ -24,14 +24,14 @@ const EXERCISES = [
   {
     title: 'Scenario: Government Compliance Deadline',
     prompt:
-      'Your agency must comply with CNSA 2.0 by 2030. You have 200+ systems using RSA-3072 and AES-128. Build a prioritized risk register with at least 4 entries covering different asset types and threat vectors.',
+      'Your agency operates national security systems subject to CNSA 2.0 (exclusive PQC by 2030 for the earliest categories). You have 200+ systems using RSA-3072 and ECDSA P-256 (both quantum-vulnerable), plus AES-128 (which CNSA 2.0 upgrades to AES-256). Build a prioritized risk register with at least 4 entries covering different asset types and threat vectors.',
     workshopStep: 1,
     workshopStepLabel: 'Step 2 — Risk Register Builder',
   },
   {
     title: 'Scenario: Compliance Gap Analysis',
     prompt:
-      'Using your completed risk register, run the Compliance Gap Analysis (Step 4). Set the CRQC year to 2032 and identify which assets would miss the NIST 2030 deprecation deadline. List the assets with the highest compliance gap risk and their recommended PQC replacements.',
+      'Using your completed risk register, run the Compliance Gap Analysis (Step 4). Set the CRQC year to 2032 and identify which assets would miss the draft NIST IR 8547 2030 deprecation milestone. List the assets with the highest compliance gap risk and their recommended PQC replacements.',
     workshopStep: 3,
     workshopStepLabel: 'Step 4 — Compliance Gap Analysis',
   },

--- a/src/components/PKILearning/modules/PlatformEngPQC/components/PlatformEngExercises.tsx
+++ b/src/components/PKILearning/modules/PlatformEngPQC/components/PlatformEngExercises.tsx
@@ -57,7 +57,7 @@ export const PlatformEngExercises: React.FC<ExercisesProps> = ({
       badge: 'Signing',
       badgeColor: 'bg-primary/20 text-primary border-primary/50',
       observe:
-        'Notation has Beta PQC readiness (available in 2025 via the AWS Crypto Tools plugin with ML-DSA-65 composite certificates). cosign is On Roadmap with a 2026 target. For new deployments requiring ML-DSA today, Notation + AWS Crypto plugin is the correct choice. Docker Content Trust (DCT) should be migrated immediately — Notary v1 has no PQC roadmap and is in maintenance mode.',
+        'Notation has early PQC readiness via the AWS Crypto Tools plugin (ML-DSA-65 composite certificates); cosign has PQC on its roadmap. Vendor timelines move quickly, so confirm current status. For new deployments requiring ML-DSA today, Notation + AWS Crypto plugin is the correct choice. Docker Content Trust (DCT) should be migrated immediately — Notary v1 has no PQC roadmap and is in maintenance mode.',
       config: { step: 2 },
     },
     {

--- a/src/components/PKILearning/modules/QuantumThreats/components/QuantumThreatsExercises.tsx
+++ b/src/components/PKILearning/modules/QuantumThreats/components/QuantumThreatsExercises.tsx
@@ -47,11 +47,11 @@ export const QuantumThreatsExercises: React.FC<QuantumThreatsExercisesProps> = (
       id: 'aes-comparison',
       title: '2. AES-128 vs AES-256 Quantum Security',
       description:
-        "Compare how Grover's algorithm affects AES-128 (drops to 64-bit, insufficient) versus AES-256 (drops to 128-bit, still secure). The fix is simple: double the key size.",
+        "Compare how Grover's algorithm affects AES-128 (a ~64-bit theoretical bound) versus AES-256 (~128-bit) in the Security Level tool. The practical takeaway: prefer AES-256 for long-term confidentiality.",
       badge: "Grover's",
       badgeColor: 'bg-warning/20 text-warning border-warning/50',
       observe:
-        "AES-128's post-quantum security (64-bit) falls below the minimum 80-bit threshold. AES-256 retains 128-bit security — the recommended NIST Level 1 minimum.",
+        "The tool shows AES-128 at a ~64-bit Grover bound and AES-256 at ~128-bit. In practice Grover's enormous circuit depth makes even AES-128 far stronger than 64 bits, so NIST still rates AES-128 at security category 1 — but AES-256 (category 5) is the safer choice for long-term data.",
       config: { step: 0, algorithmA: 'AES-128', algorithmB: 'AES-256' },
     },
     {
@@ -91,11 +91,11 @@ export const QuantumThreatsExercises: React.FC<QuantumThreatsExercisesProps> = (
       id: 'ecc-blockchain',
       title: '7. ECC Blockchain Under Quantum Attack',
       description:
-        'A Bitcoin transaction is broadcast to the mempool but not yet confirmed. Google Quantum AI (Mar 2026) demonstrated secp256k1 ECDLP can be broken with \u22641,200 logical qubits — roughly half prior estimates. Use the Security Level tool to compare secp256k1 with RSA-2048 and see why fast-clock CRQCs pose an on-spend threat before PQC migration.',
+        'A Bitcoin transaction is broadcast to the mempool but not yet confirmed. Google Quantum AI (Mar 2026) estimated that breaking secp256k1 ECDLP would require\u22641,200 logical qubits — roughly half prior estimates. Use the Security Level tool to compare secp256k1 with RSA-2048 and see why fast-clock CRQCs pose an on-spend threat before PQC migration.',
       badge: "Shor's",
       badgeColor: 'bg-destructive/20 text-destructive border-destructive/50',
       observe:
-        'secp256k1 breaks with \u22641,200 logical qubits — significantly fewer than RSA-2048 (~4,098). A fast-clock CRQC (superconducting) reaching this threshold could derive the private key from an exposed public key within the mempool confirmation window (~10 min for Bitcoin). Migration to PQC signatures is critical for blockchain infrastructure.',
+        'secp256k1 would require an estimated\u22641,200 logical qubits — significantly fewer than RSA-2048 (~4,098). A fast-clock CRQC (superconducting) reaching this threshold could derive the private key from an exposed public key within the mempool confirmation window (~10 min for Bitcoin). Migration to PQC signatures is critical for blockchain infrastructure.',
       config: { step: 0, algorithmA: 'ECDSA secp256k1' },
     },
     {

--- a/src/components/PKILearning/modules/SLHDSAModule/components/SLHDSAExercises.tsx
+++ b/src/components/PKILearning/modules/SLHDSAModule/components/SLHDSAExercises.tsx
@@ -69,7 +69,7 @@ export const SLHDSAExercises: React.FC<SLHDSAExercisesProps> = ({
       badge: 'FIPS 205 §11',
       badgeColor: 'bg-muted/40 text-foreground border-border',
       observe:
-        "HashSLH-DSA pre-hashes M before signing: M' = 0x01 || len(ctx) || ctx || OID_DER || H(M). Context strings are NOT allowed in HashSLH-DSA mode (§9.2).",
+        "HashSLH-DSA pre-hashes M before signing: M' = 0x01 || len(ctx) || ctx || OID_DER || H(M). The 0x01 prefix marks the pre-hash variant (Pure SLH-DSA uses 0x00); both variants still support an optional context string (up to 255 bytes).",
       config: { step: 1 },
     },
   ]

--- a/src/components/PKILearning/modules/SecretsManagementPQC/components/SecretsManagementExercises.tsx
+++ b/src/components/PKILearning/modules/SecretsManagementPQC/components/SecretsManagementExercises.tsx
@@ -71,7 +71,7 @@ export const SecretsManagementExercises: React.FC<SecretsManagementExercisesProp
       badge: 'Cloud',
       badgeColor: 'bg-status-warning/20 text-status-warning border-status-warning/50',
       observe:
-        'HashiCorp Vault supports native dynamic secrets (DB, AWS, GCP, Azure credential generation) with FIPS 140-3 (Enterprise), but PQC is planned rather than GA. AWS Secrets Manager has GA PQC via KMS integration but does not generate dynamic secrets natively. GCP Cloud KMS supports ML-KEM-768, ML-KEM-1024, X-Wing, ML-DSA-65, and SLH-DSA (preview), but FIPS mode is unavailable for GCP Secret Manager.',
+        'As of mid-2026 (verify against current provider docs and the workshop comparison): HashiCorp Vault offers native dynamic secrets (DB, AWS, GCP, Azure credential generation) with FIPS 140-3 (Enterprise), and added ML-DSA to its transit engine in Vault Enterprise 1.19 (with more PQC algorithms planned). AWS Secrets Manager surfaces PQC via KMS integration but does not generate dynamic secrets natively. GCP Cloud KMS lists ML-KEM-768, ML-KEM-1024, X-Wing, ML-DSA-65, and SLH-DSA in preview, while FIPS mode is not offered for GCP Secret Manager.',
       config: { step: 3 },
     },
   ]

--- a/src/components/PKILearning/modules/SecureBootPQC/components/SecureBootExercises.tsx
+++ b/src/components/PKILearning/modules/SecureBootPQC/components/SecureBootExercises.tsx
@@ -60,7 +60,7 @@ export const SecureBootExercises: React.FC<SecureBootExercisesProps> = ({
       badge: 'TPM',
       badgeColor: 'bg-warning/20 text-warning border-warning/50',
       observe:
-        'The AIK key shows "Hybrid Available" status. Expanding the Hybrid Approach section reveals that TPM 2.0\'s hardware constraint requires a two-signature pattern: RSA TPM quote proves hardware binding, ML-DSA co-signature provides quantum safety. Full PQC requires new hardware (TCG 2027 roadmap).',
+        'The AIK key shows "Hybrid Available" status. Expanding the Hybrid Approach section reveals that TPM 2.0\'s hardware constraint requires a two-signature pattern: RSA TPM quote proves hardware binding, ML-DSA co-signature provides quantum safety. Full PQC likely requires future TPM hardware (per the TCG roadmap).',
       config: { step: 2 },
     },
     {
@@ -71,7 +71,7 @@ export const SecureBootExercises: React.FC<SecureBootExercisesProps> = ({
       badge: 'Vendors',
       badgeColor: 'bg-destructive/20 text-destructive border-destructive/50',
       observe:
-        'HPE iLO 6 is the only enterprise OEM with available ML-DSA firmware signing (iLO 6.20+). EDK2 has ML-DSA merged into mainline (Q1 2026). AMI and Lenovo have 2026 roadmaps. Phoenix has no committed timeline. Intel Boot Guard PQC requires new silicon (Granite Rapids, 2026).',
+        'Firmware-vendor PQC support is early and moves fast: as of mid-2026 HPE ProLiant Gen12 / iLO7 is among the first with quantum-safe firmware signing (hash-based LMS in the silicon root of trust), open-source UEFI (EDK2/Tianocore) work is in progress, several OEMs have 2026-2027 roadmaps, and Intel Boot Guard PQC is tied to newer silicon (CNSA 2.0 requires firmware signing by 2030). Use the Firmware Vendor Matrix for current per-vendor status.',
       config: { step: 3 },
     },
     {

--- a/src/components/PKILearning/modules/StatefulSignatures/components/StatefulSigsExercises.tsx
+++ b/src/components/PKILearning/modules/StatefulSignatures/components/StatefulSigsExercises.tsx
@@ -50,7 +50,7 @@ export const StatefulSigsExercises: React.FC<StatefulSigsExercisesProps> = ({
       badge: 'XMSS',
       badgeColor: 'bg-secondary/20 text-secondary border-secondary/50',
       observe:
-        'At the same tree height (H=10), XMSS produces smaller signatures than LMS but has larger private keys due to bitmask storage. XMSS has a stronger security proof against multi-target attacks.',
+        'At the same tree height (H=10), XMSS and LMS produce comparably-sized signatures (the exact order depends on the Winternitz parameter). XMSS uses keyed hashing with per-node bitmasks, which gives it a stronger security proof against multi-target attacks.',
       config: { step: 1, paramId: 'xmss-sha2-10' },
     },
     {
@@ -62,7 +62,7 @@ export const StatefulSigsExercises: React.FC<StatefulSigsExercisesProps> = ({
       badgeColor: 'bg-warning/20 text-warning border-warning/50',
       observe:
         'XMSS^MT-SHA2_60/6 provides 2^60 signatures (over 10^18) by chaining 6 layers of 10-level trees. This is suitable for long-lived timestamping authorities that sign millions of times per year.',
-      config: { step: 1, paramId: 'xmssmt-sha2-40-4' },
+      config: { step: 1, paramId: 'xmssmt-sha2-60-6' },
     },
     {
       id: 'state-exhaustion',

--- a/src/components/PKILearning/modules/VPNSSHModule/components/VPNSSHExercises.tsx
+++ b/src/components/PKILearning/modules/VPNSSHModule/components/VPNSSHExercises.tsx
@@ -42,7 +42,7 @@ export const VPNSSHExercises: React.FC<VPNSSHExercisesProps> = ({
       badge: 'Classical',
       badgeColor: 'bg-primary/20 text-primary border-primary/50',
       observe:
-        "The total handshake is approximately 1,784 bytes across 2 round trips. The KE payload carries a 256-byte MODP-3072 public value. This baseline is quantum-vulnerable to Shor's algorithm.",
+        "The total handshake is approximately 1,784 bytes across 2 round trips. The KE payload carries a 384-byte MODP-3072 public value (3072 bits). This baseline is quantum-vulnerable to Shor's algorithm.",
       config: { step: 0, ikev2Mode: 'classical' },
     },
     {
@@ -71,11 +71,11 @@ export const VPNSSHExercises: React.FC<VPNSSHExercisesProps> = ({
       id: 'ssh-mlkem',
       title: '4. SSH with ML-KEM-768 Hybrid (OpenSSH 9.9)',
       description:
-        'Switch to mlkem768x25519-sha256, the NIST-standard hybrid KEX added in OpenSSH 9.9. Compare the message sizes with the classical X25519 exchange.',
+        'Switch to mlkem768x25519-sha256, the ML-KEM-768 + X25519 hybrid KEX added in OpenSSH 9.9 (and made the default in OpenSSH 10.0). Compare the message sizes with the classical X25519 exchange.',
       badge: 'PQC',
       badgeColor: 'bg-success/20 text-success border-success/50',
       observe:
-        'The public key grows from 32 bytes to 1,216 bytes (X25519 + ML-KEM concatenated). The total handshake is approximately 3,296 bytes — a 3.3x increase. The shared secret doubles to 64 bytes.',
+        'The public key grows from 32 bytes to 1,216 bytes (X25519 + ML-KEM concatenated). The total handshake is approximately 3,296 bytes — a 3.3x increase. The combined key material is 64 bytes (the 32-byte X25519 secret concatenated with the 32-byte ML-KEM secret) before being hashed into the final session key.',
       config: { step: 1, sshKex: 'mlkem768x25519-sha256' },
     },
     {


### PR DESCRIPTION
## What
Accuracy cleanup of the Learn module **Exercises** content across **27 modules**. Content only — **no tab or structure changes**.

## Why
An audit, followed by independent web-verification, found factual errors, imprecise compliance-timeline wording, and vendor PQC claims that had drifted from reality.

## Highlights

**Algorithm facts**
- RSA-4096 key 256→**512 B**, MODP-3072 256→**384 B**, ECDSA P-256 sig →**64 B**
- Falcon-512 "10× smaller than ML-DSA" → **~2.3×**; SLH-DSA "context not allowed" corrected; ML-KEM ciphertext/public-key labels fixed
- Kept "HNFL" (it's a real in-app term, not a typo)

**Timelines**
- CNSA 2.0 → real phased **2030/2033**, scoped to national-security systems (was wrongly applied to a commercial bank)
- NIST IR 8547 dates labeled **draft**

**Workshop wiring**
- IoTOT: two exercises were opening the wrong workshop tool — fixed
- CryptoDevAPIs: PKCS#11 `CKM_ML_DSA` (+ `CKA_PARAMETER_SET`), not the non-existent `CKM_ML_DSA_65`
- OSPQC: `sntrup761x25519` correctly labeled NTRU Prime (not ML-KEM)

**Vendor claims — web-verified against primary sources**
- ✅ Confirmed: AWS KMS ML-DSA (GA 2025), GCP Cloud KMS preview, AWS-LC (first FIPS 140-3 with ML-KEM), ETSI EN 419 241, EU PQC roadmap 2026/2030/2035, Thales Luna v7.9, Entrust nShield 5, Palo Alto PAN-OS PQC TLS inspection
- 🔧 Corrected: OpenSSH default KEX (**10.0**, not 9.9), HashiCorp Vault (**ML-DSA in transit**, not roadmap), Azure Key Vault (**PQC rolling out**), HPE iLO (**LMS** signing, not ML-DSA), RHEL FIPS (**ML-KEM hybrids** in 9.7)
- ⏳ Evolving/unconfirmable claims date-stamped and pointed at the in-app Vendor Matrix

## Verification
- `tsc -b` clean
- `vitest run src/components/PKILearning` → **653 tests pass**
- Full `npm run build` succeeds

## Note
**Do not merge yet — opened for review.** Branched off `main`, isolated from unrelated in-progress work on `feat/sim-framework-fidelity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
